### PR TITLE
cleanup: Remove the syntax for multi-declarators.

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,11 +1,10 @@
 ---
-_extends: template
+_extends: .github
 
 repository:
   name: hs-cimple
   description: Cimple and Apidsl language parsers and tools
   topics: c, dsl, parser
-  has_issues: true
 
 branches:
   - name: "master"
@@ -13,7 +12,5 @@ branches:
       required_status_checks:
         contexts:
           - Travis CI - Pull Request
-          - WIP
           - code-review/reviewable
           - coverage/coveralls
-          - license/cla

--- a/src/Language/Cimple/AST.hs
+++ b/src/Language/Cimple/AST.hs
@@ -57,7 +57,7 @@ data Node lexeme
     | Label lexeme (Node lexeme)
     -- Variable declarations
     | VLA (Node lexeme) lexeme (Node lexeme)
-    | VarDecl (Node lexeme) [Node lexeme]
+    | VarDecl (Node lexeme) (Node lexeme)
     | Declarator (Node lexeme) (Maybe (Node lexeme))
     | DeclSpecVar lexeme
     | DeclSpecArray (Node lexeme) (Maybe (Node lexeme))

--- a/src/Language/Cimple/Parser.y
+++ b/src/Language/Cimple/Parser.y
@@ -356,7 +356,7 @@ ForInit :: { Maybe (StringNode) }
 ForInit
 :	';'							{ Nothing }
 |	AssignExpr ';'						{ Just $1 }
-|	SingleVarDecl						{ Just $1 }
+|	VarDecl							{ Just $1 }
 
 ForNext :: { StringNode }
 ForNext
@@ -386,18 +386,9 @@ DeclStmt
 :	VarDecl							{ $1 }
 |	VLA '(' QualType ',' IdVar ',' Expr ')' ';'		{ VLA $3 $5 $7 }
 
-SingleVarDecl :: { StringNode }
-SingleVarDecl
-:	QualType Declarator ';'					{ VarDecl $1 [$2] }
-
 VarDecl :: { StringNode }
 VarDecl
-:	QualType Declarators ';'				{ VarDecl $1 (reverse $2) }
-
-Declarators :: { [StringNode] }
-Declarators
-:	Declarator						{ [$1] }
-|	Declarators ',' Declarator				{ $3 : $1 }
+:	QualType Declarator ';'					{ VarDecl $1 $2 }
 
 Declarator :: { StringNode }
 Declarator

--- a/src/Language/Cimple/Pretty.hs
+++ b/src/Language/Cimple/Pretty.hs
@@ -147,9 +147,6 @@ ppDeclSpec (DeclSpecArray dspec dim) = ppDeclSpec dspec <> ppDim dim
     ppDim (Just x) = char '[' <> ppExpr x <> char ']'
 ppDeclSpec x = error $ groom x
 
-ppDeclaratorList :: [Node (Lexeme Text)] -> Doc
-ppDeclaratorList = ppCommaSep ppDeclarator
-
 ppDeclarator :: Node (Lexeme Text) -> Doc
 ppDeclarator (Declarator dspec Nothing) =
     ppDeclSpec dspec
@@ -544,7 +541,7 @@ ppDecl decl = case decl of
     Break                 -> text "break;"
     Return Nothing        -> text "return;"
     Return (Just e)       -> text "return" <+> ppExpr e <> char ';'
-    VarDecl ty declrs     -> ppType ty <+> ppDeclaratorList declrs <> char ';'
+    VarDecl ty declr      -> ppType ty <+> ppDeclarator declr <> char ';'
     IfStmt cond t e       -> ppIfStmt cond t e
     ForStmt i c n body    -> ppForStmt i c n body
     Default s             -> text "default:" <+> ppStmt s

--- a/src/Language/Cimple/TraverseAst.hs
+++ b/src/Language/Cimple/TraverseAst.hs
@@ -122,8 +122,8 @@ instance TraverseAst (Node (Lexeme Text)) where
             Label <$> recurse label <*> recurse stmt
         VLA ty name size ->
             VLA <$> recurse ty <*> recurse name <*> recurse size
-        VarDecl ty decls ->
-            VarDecl <$> recurse ty <*> recurse decls
+        VarDecl ty decl ->
+            VarDecl <$> recurse ty <*> recurse decl
         Declarator spec value ->
             Declarator <$> recurse spec <*> recurse value
         DeclSpecVar name ->

--- a/test/Language/Cimple/PrettySpec.hs
+++ b/test/Language/Cimple/PrettySpec.hs
@@ -99,3 +99,9 @@ spec = do
                 >>= (`shouldBe` "void foo(int a, ...);\n")
             compact "void foo(int a, const char *msg, ...);"
                 >>= (`shouldBe` "void foo(int a, char const* msg, ...);\n")
+
+        it "supports C preprocessor directives" $ do
+            compact "#define XYZZY 123\n"
+                >>= (`shouldBe` "#define XYZZY 123\n")
+            compact "#include <tox/tox.h>\n"
+                >>= (`shouldBe` "#include <tox/tox.h>\n")

--- a/test/Language/CimpleSpec.hs
+++ b/test/Language/CimpleSpec.hs
@@ -66,3 +66,27 @@ spec =
             ast <- parseText "/* hello */"
             ast `shouldBe` Right
                 [Comment Regular [CommentWord (L (AlexPn 3 1 4) CmtWord "hello")]]
+
+        it "supports single declarators" $ do
+            ast <- parseText "int main() { int a; }"
+            ast `shouldBe` Right
+                [ FunctionDefn
+                      Global
+                      (FunctionPrototype
+                          (TyStd (L (AlexPn 0 1 1) IdStdType "int"))
+                          (L (AlexPn 4 1 5) IdVar "main")
+                          []
+                      )
+                      [ VarDecl
+                            (TyStd (L (AlexPn 13 1 14) IdStdType "int"))
+                            (Declarator
+                                (DeclSpecVar (L (AlexPn 17 1 18) IdVar "a"))
+                                Nothing
+                            )
+                      ]
+                ]
+
+        it "does not support multiple declarators per declaration" $ do
+            ast <- parseText "int main() { int a, b; }"
+            ast `shouldBe` Left
+                "Parse error near token: L (AlexPn 18 1 19) PctComma \",\""


### PR DESCRIPTION
We no longer allow `int a, b;` or any variant of that declaration. No
support for multiple declarators per declaration. It turns out that most
instances of this syntax was a bad idea in the first place (so it's good
to disallow), and the few that were kind of useful were maybe 3-4 and it
didn't add much value to support this syntax given its potential (and
real! in toxcore!) abuses.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/hs-cimple/4)
<!-- Reviewable:end -->
