### PR TITLE
feat: Tighten the style on comments.

### DIFF
--- a/cimple.cabal
+++ b/cimple.cabal
@@ -94,6 +94,7 @@ test-suite testsuite
   main-is: testsuite.hs
   other-modules:
       Language.CimpleSpec
+    , Language.Cimple.PrettySpec
   ghc-options:
       -Wall
       -fno-warn-unused-imports

--- a/src/Language/Cimple/AST.hs
+++ b/src/Language/Cimple/AST.hs
@@ -33,7 +33,7 @@ data Node lexeme
     | MacroBodyFunCall (Node lexeme)
     | MacroParam lexeme
     -- Comments
-    | Comment CommentStyle [Node lexeme]
+    | Comment CommentStyle lexeme [Node lexeme] lexeme
     | CommentBlock lexeme
     | CommentWord lexeme
     | Commented (Node lexeme) (Node lexeme)

--- a/src/Language/Cimple/Lexer.x
+++ b/src/Language/Cimple/Lexer.x
@@ -236,14 +236,17 @@ tokens :-
 <cmtSC>		"`"([^`]|"\`")+"`"			{ mkL CmtCode }
 <cmtSC>		"–"					{ mkL CmtWord }
 <cmtSC>		"*/"					{ mkL CmtEnd `andBegin` 0 }
-<cmtSC>		\n" "+"*"+"/"				{ mkL CmtEnd `andBegin` 0 }
-<cmtSC,codeSC>	\n" "+"*"				{ mkL PpNewline }
-<cmtSC,codeSC>	\n					{ mkL PpNewline }
+<cmtSC>		\n					{ mkL PpNewline `andBegin` cmtNewlineSC }
 <cmtSC>		" "+					;
+
+<cmtNewlineSC>	" "+"*"+"/"				{ mkL CmtEnd `andBegin` 0 }
+<cmtNewlineSC>	" "+"*"					{ mkL CmtIndent `andBegin` cmtSC }
 
 -- <code></code> blocks in comments.
 <codeSC>	"@endcode"				{ mkL CmtCode `andBegin` cmtSC }
 <codeSC>	"</code>"				{ mkL CmtCode `andBegin` cmtSC }
+<codeSC>	\n					{ mkL PpNewline }
+<codeSC>	\n" "+"*"				{ mkL PpNewline }
 <codeSC>	[^@\<]+					{ mkL CmtCode }
 
 -- Error handling.

--- a/src/Language/Cimple/Parser.y
+++ b/src/Language/Cimple/Parser.y
@@ -121,6 +121,7 @@ import           Language.Cimple.Tokens (LexemeClass (..))
     '/*'			{ L _ CmtStart			_ }
     '/**'			{ L _ CmtStartDoc		_ }
     '/***'			{ L _ CmtStartBlock		_ }
+    ' * '			{ L _ CmtIndent			_ }
     '*/'			{ L _ CmtEnd			_ }
     'Copyright'			{ L _ CmtSpdxCopyright		_ }
     'License'			{ L _ CmtSpdxLicense		_ }
@@ -208,9 +209,9 @@ ErrorDecl
 
 Comment :: { StringNode }
 Comment
-:	'/*' CommentBody '*/'					{ Comment Regular (reverse $2) }
-|	'/**' CommentBody '*/'					{ Comment Doxygen (reverse $2) }
-|	'/***' CommentBody '*/'					{ Comment Block (reverse $2) }
+:	'/*' CommentBody '*/'					{ Comment Regular $1 (reverse $2) $3 }
+|	'/**' CommentBody '*/'					{ Comment Doxygen $1 (reverse $2) $3 }
+|	'/***' CommentBody '*/'					{ Comment Block $1 (reverse $2) $3 }
 |	'/**/'							{ CommentBlock $1 }
 
 CommentBody :: { [StringNode] }
@@ -242,6 +243,7 @@ CommentWord
 |	'-'							{ CommentWord $1 }
 |	'='							{ CommentWord $1 }
 |	'\n'							{ CommentWord $1 }
+|	' * '							{ CommentWord $1 }
 
 PreprocIfdef(decls)
 :	'#ifdef' ID_CONST decls PreprocElse(decls) '#endif'	{ PreprocIfdef $2 $3 $4 }

--- a/src/Language/Cimple/Tokens.hs
+++ b/src/Language/Cimple/Tokens.hs
@@ -107,6 +107,7 @@ data LexemeClass
     | PpNewline
     | PpUndef
     | CmtBlock
+    | CmtIndent
     | CmtStart
     | CmtStartBlock
     | CmtStartDoc

--- a/src/Language/Cimple/TraverseAst.hs
+++ b/src/Language/Cimple/TraverseAst.hs
@@ -84,8 +84,8 @@ instance TraverseAst (Node (Lexeme Text)) where
             MacroBodyFunCall <$> recurse expr
         MacroParam name ->
             MacroParam <$> recurse name
-        Comment doc contents ->
-            Comment doc <$> recurse contents
+        Comment doc start contents end ->
+            Comment doc <$> recurse start <*> recurse contents <*> recurse end
         CommentBlock comment ->
             CommentBlock <$> recurse comment
         CommentWord word ->

--- a/test/Language/Cimple/PrettySpec.hs
+++ b/test/Language/Cimple/PrettySpec.hs
@@ -59,21 +59,25 @@ spec = do
                 , "} Foo;"
                 ]
 
+        it "respects newlines at end of comments" $ do
+            compact "/* foo bar */" >>= (`shouldBe` "/* foo bar */\n")
+            compact "/* foo bar\n */" >>= (`shouldBe` "/* foo bar\n */\n")
+
         it "respects comment styles" $ do
-            compact "/* foo bar */" >>= (`shouldBe` "/* foo bar\n */\n")
-            compact "/** foo bar */" >>= (`shouldBe` "/** foo bar\n */\n")
-            compact "/*** foo bar */" >>= (`shouldBe` "/*** foo bar\n */\n")
-            compact "/**** foo bar */" >>= (`shouldBe` "/*** foo bar\n */\n")
+            compact "/* foo bar */" >>= (`shouldBe` "/* foo bar */\n")
+            compact "/** foo bar */" >>= (`shouldBe` "/** foo bar */\n")
+            compact "/*** foo bar */" >>= (`shouldBe` "/*** foo bar */\n")
+            compact "/**** foo bar */" >>= (`shouldBe` "/*** foo bar */\n")
 
         it "supports punctuation in comments" $ do
             compact "/* foo.bar,baz-blep */"
-                >>= (`shouldBe` "/* foo. bar, baz - blep\n */\n")
-            compact "/* foo? */" >>= (`shouldBe` "/* foo ?\n */\n")
+                >>= (`shouldBe` "/* foo. bar, baz - blep */\n")
+            compact "/* foo? */" >>= (`shouldBe` "/* foo ? */\n")
 
         it "formats number ranges and negative numbers without spacing" $ do
-            compact "/* 123 - 456 */" >>= (`shouldBe` "/* 123-456\n */\n")
-            compact "/* - 3 */" >>= (`shouldBe` "/* -3\n */\n")
-            compact "/* a-b */" >>= (`shouldBe` "/* a - b\n */\n")
+            compact "/* 123 - 456 */" >>= (`shouldBe` "/* 123-456 */\n")
+            compact "/* - 3 */" >>= (`shouldBe` "/* -3 */\n")
+            compact "/* a-b */" >>= (`shouldBe` "/* a - b */\n")
 
         it "formats pointer types with east-const" $ do
             compact "void foo(const int *a);"

--- a/test/Language/CimpleSpec.hs
+++ b/test/Language/CimpleSpec.hs
@@ -65,7 +65,11 @@ spec =
         it "should parse a comment" $ do
             ast <- parseText "/* hello */"
             ast `shouldBe` Right
-                [Comment Regular [CommentWord (L (AlexPn 3 1 4) CmtWord "hello")]]
+                [ Comment Regular
+                          (L (AlexPn 0 1 1) CmtStart "/*")
+                          [CommentWord (L (AlexPn 3 1 4) CmtWord "hello")]
+                          (L (AlexPn 9 1 10) CmtEnd "*/")
+                ]
 
         it "supports single declarators" $ do
             ast <- parseText "int main() { int a; }"


### PR DESCRIPTION
We must now always start each line of a comment with `*`. This
simplifies newline handling a bit in preparation for distinguishing
attached and detached comments.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/hs-cimple/5)
<!-- Reviewable:end -->
