### PR TITLE
perf: Use StrictData for all modules that define data types.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,9 +1,9 @@
 ---
 cirrus-ci_task:
   container:
-    image: toxchat/toktok-stack:0.0.15
+    image: toxchat/toktok-stack:0.0.17
     cpu: 2
-    memory: 4G
+    memory: 6G
   configure_script:
     - /src/workspace/tools/inject-repo hs-cimple
   test_all_script:

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -11,7 +11,7 @@ branches:
     protection:
       required_status_checks:
         contexts:
-          - "Cabal Build / build (pull_request)"
+          - "build"
           - "cirrus-ci"
           - "Codacy Static Code Analysis"
           - "code-review/reviewable"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,7 @@ jobs:
         run: cabal haddock --haddock-for-hackage --enable-doc
 
       - name: Publish candidate to Hackage
+        if: ${{ github.event_name == 'push' }}
         env:
           API_TOKEN_HACKAGE: ${{ secrets.API_TOKEN_HACKAGE }}
         run: |

--- a/cimple.cabal
+++ b/cimple.cabal
@@ -98,6 +98,8 @@ test-suite testsuite
   ghc-options:
       -Wall
       -fno-warn-unused-imports
+  build-tool-depends:
+      hspec-discover:hspec-discover
   build-depends:
       base < 5
     , ansi-wl-pprint

--- a/src/Language/Cimple/AST.hs
+++ b/src/Language/Cimple/AST.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DeriveFunctor     #-}
 {-# LANGUAGE DeriveGeneric     #-}
 {-# LANGUAGE DeriveTraversable #-}
+{-# LANGUAGE StrictData        #-}
 module Language.Cimple.AST
     ( AssignOp (..)
     , BinaryOp (..)

--- a/src/Language/Cimple/Diagnostics.hs
+++ b/src/Language/Cimple/Diagnostics.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE StrictData        #-}
 module Language.Cimple.Diagnostics (Diagnostics, warn) where
 
 import           Control.Monad.State.Lazy (State)

--- a/src/Language/Cimple/IO.hs
+++ b/src/Language/Cimple/IO.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE StrictData #-}
 module Language.Cimple.IO
     ( parseFile
     , parseText

--- a/src/Language/Cimple/Tokens.hs
+++ b/src/Language/Cimple/Tokens.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE StrictData    #-}
 module Language.Cimple.Tokens
     ( LexemeClass (..)
     ) where

--- a/src/Language/Cimple/TraverseAst.hs
+++ b/src/Language/Cimple/TraverseAst.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE InstanceSigs        #-}
 {-# LANGUAGE LambdaCase          #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StrictData          #-}
 module Language.Cimple.TraverseAst
     ( TraverseAst (..)
     , AstActions (..)


### PR DESCRIPTION
I've added StrictData to some modules that don't currently define data
types, mostly by mistake, but it doesn't harm and avoids missing it in
the future.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/hs-cimple/8)
<!-- Reviewable:end -->
