### PR TITLE
feat: Add support for `static_assert`.

### DIFF
--- a/src/Language/Cimple/AST.hs
+++ b/src/Language/Cimple/AST.hs
@@ -26,13 +26,13 @@ data Node lexeme
     | PreprocIfndef lexeme [Node lexeme] (Node lexeme)
     | PreprocElse [Node lexeme]
     | PreprocElif (Node lexeme) [Node lexeme] (Node lexeme)
-    | PreprocError lexeme
     | PreprocUndef lexeme
     | PreprocDefined lexeme
     | PreprocScopedDefine (Node lexeme) [Node lexeme] (Node lexeme)
     | MacroBodyStmt [Node lexeme]
     | MacroBodyFunCall (Node lexeme)
     | MacroParam lexeme
+    | StaticAssert (Node lexeme) lexeme
     -- Comments
     | Comment CommentStyle lexeme [Node lexeme] lexeme
     | CommentBlock lexeme

--- a/src/Language/Cimple/Lexer.x
+++ b/src/Language/Cimple/Lexer.x
@@ -82,9 +82,8 @@ tokens :-
 <0,ppSC>	"crypto_box_"[A-Z][A-Z0-9_]*		{ mkL IdConst }
 <0,ppSC>	"crypto_hash_sha256_"[A-Z][A-Z0-9_]*	{ mkL IdConst }
 <0,ppSC>	"crypto_hash_sha512_"[A-Z][A-Z0-9_]*	{ mkL IdConst }
+<0,ppSC>	"crypto_pwhash_scryptsalsa208sha256_"[A-Z][A-Z0-9_]*		{ mkL IdConst }
 <0,ppSC>	"crypto_sign_"[A-Z][A-Z0-9_]*		{ mkL IdConst }
-<0>		"MAX"					{ mkL IdConst }
-<0>		"MIN"					{ mkL IdConst }
 
 -- Standard C (ish).
 <ppSC>		defined					{ mkL PpDefined }
@@ -115,7 +114,6 @@ tokens :-
 <0>		"#define"				{ mkL PpDefine `andBegin` ppSC }
 <0>		"#undef"				{ mkL PpUndef }
 <0>		"#include"				{ mkL PpInclude }
-<0>		"#error"				{ mkL PpError }
 <0,ppSC>	"bitmask"				{ mkL KwBitmask }
 <0,ppSC>	"break"					{ mkL KwBreak }
 <0,ppSC>	"case"					{ mkL KwCase }
@@ -136,6 +134,7 @@ tokens :-
 <0,ppSC>	"return"				{ mkL KwReturn }
 <0,ppSC>	"sizeof"				{ mkL KwSizeof }
 <0,ppSC>	"static"				{ mkL KwStatic }
+<0,ppSC>	"static_assert"				{ mkL KwStaticAssert }
 <0,ppSC>	"struct"				{ mkL KwStruct }
 <0,ppSC>	"switch"				{ mkL KwSwitch }
 <0,ppSC>	"this"					{ mkL KwThis }

--- a/src/Language/Cimple/Pretty.hs
+++ b/src/Language/Cimple/Pretty.hs
@@ -416,9 +416,6 @@ ppDecl decl = case decl of
     PreprocScopedDefine def stmts undef ->
         ppDecl def <$> ppStmtList stmts <$> ppDecl undef
 
-    PreprocError msg ->
-        text "#error" <+> ppLexeme msg
-
     PreprocInclude hdr ->
         text "#include" <+> ppLexeme hdr
     PreprocDefine name ->
@@ -429,6 +426,9 @@ ppDecl decl = case decl of
         text "#define" <+> ppLexeme name <> ppMacroParamList params <+> ppMacroBody body
     PreprocUndef name ->
         text "#undef" <+> ppLexeme name
+
+    StaticAssert cond msg ->
+        text "static_assert" <+> ppExpr cond <> char ',' <+> ppLexeme msg <> text ");"
 
     Comment style _ cs _ ->
         ppComment style cs

--- a/src/Language/Cimple/Tokens.hs
+++ b/src/Language/Cimple/Tokens.hs
@@ -34,6 +34,7 @@ data LexemeClass
     | KwReturn
     | KwSizeof
     | KwStatic
+    | KwStaticAssert
     | KwStruct
     | KwSwitch
     | KwThis
@@ -100,7 +101,6 @@ data LexemeClass
     | PpElif
     | PpElse
     | PpEndif
-    | PpError
     | PpIf
     | PpIfdef
     | PpIfndef

--- a/src/Language/Cimple/TraverseAst.hs
+++ b/src/Language/Cimple/TraverseAst.hs
@@ -71,8 +71,6 @@ instance TraverseAst (Node (Lexeme Text)) where
             PreprocElse <$> recurse decls
         PreprocElif cond decls elseBranch ->
             PreprocElif <$> recurse cond <*> recurse decls <*> recurse elseBranch
-        PreprocError msg ->
-            PreprocError <$> recurse msg
         PreprocUndef name ->
             PreprocUndef <$> recurse name
         PreprocDefined name ->
@@ -85,6 +83,8 @@ instance TraverseAst (Node (Lexeme Text)) where
             MacroBodyFunCall <$> recurse expr
         MacroParam name ->
             MacroParam <$> recurse name
+        StaticAssert cond msg ->
+            StaticAssert <$> recurse cond <*> recurse msg
         Comment doc start contents end ->
             Comment doc <$> recurse start <*> recurse contents <*> recurse end
         CommentBlock comment ->

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,6 +1,6 @@
 ---
 packages: [.]
-resolver: lts-14.27
+resolver: lts-18.18
 extra-deps:
   - msgpack-binary-0.0.14@sha256:46c3cf9090ad07d45c79cb74a94c05548ce9f2b5e9d78a497de80ceb5bf55014,2383
   - msgpack-types-0.0.4@sha256:3b045ea90ba9ba62de9538aa7e7915d1356e2cc34ebdb02f4472ee5b981bcab7,1940


### PR DESCRIPTION
Removed support for `#error`, which will be replaced by `static_assert`
in c-toxcore code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/hs-cimple/10)
<!-- Reviewable:end -->
