### PR TITLE
feat: Implement include-graph tool.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -59,7 +59,7 @@ haskell_library(
         ],
     ),
     src_strip_prefix = "src",
-    version = "0.0.1",
+    version = "0.0.2",
     visibility = ["//visibility:public"],
     deps = [
         ":lexer",
@@ -70,6 +70,7 @@ haskell_library(
         hazel_library("base"),
         hazel_library("bytestring"),
         hazel_library("containers"),
+        hazel_library("filepath"),
         hazel_library("groom"),
         hazel_library("mtl"),
         hazel_library("text"),

--- a/cimple.cabal
+++ b/cimple.cabal
@@ -1,5 +1,5 @@
 name:                 cimple
-version:              0.0.1
+version:              0.0.2
 synopsis:             Simple C-like programming language
 homepage:             https://toktok.github.io/
 license:              GPL-3
@@ -34,9 +34,12 @@ library
     , Language.Cimple.TraverseAst
   other-modules:
       Language.Cimple.AST
+    , Language.Cimple.Graph
     , Language.Cimple.Lexer
     , Language.Cimple.Parser
+    , Language.Cimple.SemCheck.Includes
     , Language.Cimple.Tokens
+    , Language.Cimple.TranslationUnit
   build-depends:
       base < 5
     , aeson
@@ -44,6 +47,7 @@ library
     , array
     , bytestring
     , containers
+    , filepath
     , groom
     , mtl
     , text

--- a/src/Language/Cimple/AST.hs
+++ b/src/Language/Cimple/AST.hs
@@ -34,6 +34,8 @@ data Node lexeme
     | MacroParam lexeme
     | StaticAssert (Node lexeme) lexeme
     -- Comments
+    | LicenseDecl lexeme [Node lexeme]
+    | CopyrightDecl lexeme (Maybe lexeme) [lexeme]
     | Comment CommentStyle lexeme [Node lexeme] lexeme
     | CommentBlock lexeme
     | CommentWord lexeme

--- a/src/Language/Cimple/Graph.hs
+++ b/src/Language/Cimple/Graph.hs
@@ -1,0 +1,30 @@
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE StrictData      #-}
+module Language.Cimple.Graph
+  ( Graph
+  , fromEdges
+  , edges
+  ) where
+
+import qualified Data.Graph as G
+
+data Graph node key = Graph
+    { graph          :: G.Graph
+    , nodeFromVertex :: G.Vertex -> (node, key, [key])
+    , vertexFromKey  :: key -> Maybe G.Vertex
+    }
+
+fromEdges :: Ord key => [(node, key, [key])] -> Graph node key
+fromEdges es = Graph{..}
+  where
+    (graph, nodeFromVertex, vertexFromKey) = G.graphFromEdges es
+
+edges :: Graph node key -> [(key, key)]
+edges Graph{..} = map resolve . G.edges $ graph
+  where
+    resolve (from, to) =
+      let
+          (_, from', _) = nodeFromVertex from
+          (_, to', _) = nodeFromVertex to
+      in
+      (from', to')

--- a/src/Language/Cimple/IO.hs
+++ b/src/Language/Cimple/IO.hs
@@ -1,5 +1,4 @@
-{-# LANGUAGE StrictData    #-}
-{-# LANGUAGE TupleSections #-}
+{-# LANGUAGE StrictData #-}
 module Language.Cimple.IO
     ( parseFile
     , parseFiles
@@ -7,18 +6,19 @@ module Language.Cimple.IO
     , parseText
     ) where
 
-import           Control.Monad.State.Lazy (State, get, put, runState)
-import qualified Data.ByteString          as BS
-import           Data.Map.Strict          (Map)
-import qualified Data.Map.Strict          as Map
-import           Data.Text                (Text)
-import qualified Data.Text                as Text
-import qualified Data.Text.Encoding       as Text
-import           Language.Cimple.AST      (Node (..))
-import           Language.Cimple.Lexer    (Lexeme, runAlex)
-import           Language.Cimple.Parser   (parseCimple)
-import           Language.Cimple.Program  (Program, TranslationUnit)
-import qualified Language.Cimple.Program  as Program
+import           Control.Monad.State.Lazy        (State, evalState, get, put)
+import qualified Data.ByteString                 as BS
+import           Data.Map.Strict                 (Map)
+import qualified Data.Map.Strict                 as Map
+import           Data.Text                       (Text)
+import qualified Data.Text                       as Text
+import qualified Data.Text.Encoding              as Text
+import           Language.Cimple.AST             (Node (..))
+import           Language.Cimple.Lexer           (Lexeme, runAlex)
+import           Language.Cimple.Parser          (parseCimple)
+import           Language.Cimple.Program         (Program)
+import qualified Language.Cimple.Program         as Program
+import           Language.Cimple.TranslationUnit (TranslationUnit)
 
 type CacheState a = State (Map String Text) a
 
@@ -36,7 +36,7 @@ cacheText s = do
 
 process :: [Node (Lexeme String)] -> [Node (Lexeme Text)]
 process stringAst =
-    fst $ runState (mapM (mapM (mapM cacheText)) stringAst) Map.empty
+    evalState (mapM (mapM (mapM cacheText)) stringAst) Map.empty
 
 
 parseText :: Text -> Either String [Node (Lexeme Text)]
@@ -48,9 +48,14 @@ parseText contents =
 
 
 parseFile :: FilePath -> IO (Either String (TranslationUnit Text))
-parseFile source = do
-    putStrLn $ "Processing " ++ source
-    fmap (source,) . parseText . Text.decodeUtf8 <$> BS.readFile source
+parseFile source =
+    addSource . parseText . Text.decodeUtf8 <$> BS.readFile source
+  where
+    -- Add source filename to the error message, if any.
+    addSource (Left err) = Left $ "In file \"" <> source <> "\": " <> err
+    -- If there's no error message, record the source filename in the returned
+    -- TranslationUnit.
+    addSource (Right ok) = Right (source, ok)
 
 
 parseFiles :: [FilePath] -> IO (Either String [TranslationUnit Text])
@@ -58,4 +63,4 @@ parseFiles sources = sequenceA <$> traverse parseFile sources
 
 
 parseProgram :: [FilePath] -> IO (Either String (Program Text))
-parseProgram sources = fmap Program.fromList <$> parseFiles sources
+parseProgram sources = (>>= Program.fromList) <$> parseFiles sources

--- a/src/Language/Cimple/Pretty.hs
+++ b/src/Language/Cimple/Pretty.hs
@@ -427,6 +427,8 @@ ppDecl decl = case decl of
         ppComment style cs
     CommentBlock cs ->
         ppLexeme cs
+    Commented c d ->
+        ppDecl c <$> ppDecl d
 
     ClassForward name [] ->
         text "class" <+> ppLexeme name <> char ';'

--- a/src/Language/Cimple/Program.hs
+++ b/src/Language/Cimple/Program.hs
@@ -1,27 +1,43 @@
-{-# LANGUAGE StrictData #-}
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE StrictData      #-}
 module Language.Cimple.Program
   ( Program
-  , TranslationUnit
   , fromList
   , toList
+  , includeGraph
   ) where
 
-import           Data.Map.Strict       (Map)
-import qualified Data.Map.Strict       as Map
-import           Language.Cimple.AST   (Node (..))
-import           Language.Cimple.Lexer (Lexeme)
+import           Data.Map.Strict                   (Map)
+import qualified Data.Map.Strict                   as Map
+import           Data.Text                         (Text)
+import           Language.Cimple.AST               (Node (..))
+import           Language.Cimple.Graph             (Graph)
+import qualified Language.Cimple.Graph             as Graph
+import           Language.Cimple.Lexer             (Lexeme (..))
+import           Language.Cimple.SemCheck.Includes (collectIncludes,
+                                                    normaliseIncludes)
+import           Language.Cimple.TranslationUnit   (TranslationUnit)
 
-
-type TranslationUnit a = (FilePath, [Node (Lexeme a)])
 
 data Program a = Program
-  { progAsts :: Map FilePath [Node (Lexeme a)]
+  { progAsts     :: Map FilePath [Node (Lexeme a)]
+  , progIncludes :: Graph () FilePath
   }
-
-
-fromList :: [TranslationUnit a] -> Program a
-fromList = Program . Map.fromList
 
 
 toList :: Program a -> [TranslationUnit a]
 toList = Map.toList . progAsts
+
+
+includeGraph :: Program a -> [(FilePath, FilePath)]
+includeGraph = Graph.edges . progIncludes
+
+
+fromList :: [TranslationUnit Text] -> Either String (Program Text)
+fromList tus = do
+    let tusWithIncludes = map normaliseIncludes tus
+    let progAsts = Map.fromList . map fst $ tusWithIncludes
+    -- Check whether all includes can be resolved.
+    includeEdges <- mapM (uncurry $ collectIncludes $ map fst tus) tusWithIncludes
+    let progIncludes = Graph.fromEdges includeEdges
+    return Program{..}

--- a/src/Language/Cimple/SemCheck/Includes.hs
+++ b/src/Language/Cimple/SemCheck/Includes.hs
@@ -1,0 +1,59 @@
+{-# LANGUAGE StrictData #-}
+module Language.Cimple.SemCheck.Includes
+  ( collectIncludes
+  , normaliseIncludes
+  ) where
+
+import           Control.Monad.State.Lazy        (State)
+import qualified Control.Monad.State.Lazy        as State
+import           Data.Text                       (Text)
+import qualified Data.Text                       as Text
+import           Language.Cimple.AST             (Node (..))
+import           Language.Cimple.Lexer           (Lexeme (..))
+import           Language.Cimple.Tokens          (LexemeClass (..))
+import           Language.Cimple.TranslationUnit (TranslationUnit)
+import           Language.Cimple.TraverseAst     (AstActions (..),
+                                                  defaultActions, traverseAst)
+import           System.FilePath                 (joinPath, splitPath,
+                                                  takeDirectory)
+
+collectIncludes
+  :: [FilePath]
+  -> TranslationUnit Text
+  -> [FilePath]
+  -> Either String ((), FilePath, [FilePath])
+collectIncludes sources (file, _) includes =
+    case filter (not . (`elem` sources)) includes of
+        []        -> Right ((), file, includes)
+        missing:_ -> Left $ file <> " includes missing " <> missing
+
+
+relativeTo :: FilePath -> FilePath -> FilePath
+relativeTo "." file = file
+relativeTo dir file = go (splitPath dir) (splitPath file)
+  where
+    go d ("../":f) = go (init d) f
+    go d f         = joinPath (d ++ f)
+
+
+normaliseIncludes :: TranslationUnit Text -> (TranslationUnit Text, [FilePath])
+normaliseIncludes (file, ast) =
+    ((file, ast'), includes)
+  where
+    (ast', includes) = State.runState (traverseAst (go (takeDirectory file)) ast) []
+
+    go :: FilePath -> AstActions (State [FilePath]) Text
+    go dir = defaultActions
+        { doNode = \node act ->
+            case node of
+                PreprocInclude (L spos LitString include) -> do
+                    let includePath = relativeTo dir $ tread include
+                    State.modify (includePath :)
+                    return $ PreprocInclude (L spos LitString (tshow includePath))
+
+                _ -> act
+        }
+
+      where
+        tshow = Text.pack . show
+        tread = read . Text.unpack

--- a/src/Language/Cimple/TranslationUnit.hs
+++ b/src/Language/Cimple/TranslationUnit.hs
@@ -1,0 +1,9 @@
+{-# LANGUAGE StrictData #-}
+module Language.Cimple.TranslationUnit
+  ( TranslationUnit
+  ) where
+
+import           Language.Cimple.AST   (Node)
+import           Language.Cimple.Lexer (Lexeme)
+
+type TranslationUnit a = (FilePath, [Node (Lexeme a)])

--- a/test/Language/Cimple/PrettySpec.hs
+++ b/test/Language/Cimple/PrettySpec.hs
@@ -73,7 +73,7 @@ spec = do
 
         it "respects comment styles" $ do
             compact "/* foo bar */" `shouldBe` "/* foo bar */\n"
-            compact "/** foo bar */" `shouldBe` "/** foo bar */\n"
+            compact "/** foo bar */ int a(void);" `shouldBe` "/** foo bar */\nint a(void);\n"
             compact "/*** foo bar */" `shouldBe` "/*** foo bar */\n"
             compact "/**** foo bar */" `shouldBe` "/*** foo bar */\n"
 

--- a/test/Language/CimpleSpec.hs
+++ b/test/Language/CimpleSpec.hs
@@ -93,4 +93,4 @@ spec =
         it "does not support multiple declarators per declaration" $ do
             let ast = parseText "int main() { int a, b; }"
             ast `shouldBe` Left
-                "Parse error near token: L (AlexPn 18 1 19) PctComma \",\""
+                "Parse error near token: L (AlexPn 18 1 19) PctComma \",\"; expected one of [\"';'\"]"

--- a/tools/include-graph.hs
+++ b/tools/include-graph.hs
@@ -14,7 +14,7 @@ main = do
     srcs ->
       parseProgram srcs
       >>= getRight
-      >>= mapM_ (putStrLn . groom) . Program.toList
+      >>= mapM_ (putStrLn . groom) . Program.includeGraph
   where
     getRight (Left err) = fail err
     getRight (Right ok) = return ok


### PR DESCRIPTION
Given a complete set of input files, this will print all the local
includes (ones with `"file.h"`, not `<file.h>`) for each file. The tool
will fail if any include is not part of the input file list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/hs-cimple/15)
<!-- Reviewable:end -->
