### PR TITLE
cleanup: Wrap all compound statements in CompoundStmt.

### DIFF
--- a/src/Language/Cimple/AST.hs
+++ b/src/Language/Cimple/AST.hs
@@ -30,16 +30,15 @@ data Node attr lexeme
     | PreprocUndef lexeme
     | PreprocDefined lexeme
     | PreprocScopedDefine (Node attr lexeme) [Node attr lexeme] (Node attr lexeme)
-    | MacroBodyStmt [Node attr lexeme]
+    | MacroBodyStmt (Node attr lexeme)
     | MacroBodyFunCall (Node attr lexeme)
     | MacroParam lexeme
     | StaticAssert (Node attr lexeme) lexeme
     -- Comments
     | LicenseDecl lexeme [Node attr lexeme]
     | CopyrightDecl lexeme (Maybe lexeme) [lexeme]
-    | Comment CommentStyle lexeme [Node attr lexeme] lexeme
+    | Comment CommentStyle lexeme [lexeme] lexeme
     | CommentBlock lexeme
-    | CommentWord lexeme
     | Commented (Node attr lexeme) (Node attr lexeme)
     -- Namespace-like blocks
     | ExternC [Node attr lexeme]
@@ -52,10 +51,10 @@ data Node attr lexeme
     | Continue
     | Return (Maybe (Node attr lexeme))
     | SwitchStmt (Node attr lexeme) [Node attr lexeme]
-    | IfStmt (Node attr lexeme) [Node attr lexeme] (Maybe (Node attr lexeme))
-    | ForStmt (Node attr lexeme) (Node attr lexeme) (Node attr lexeme) [Node attr lexeme]
-    | WhileStmt (Node attr lexeme) [Node attr lexeme]
-    | DoWhileStmt [Node attr lexeme] (Node attr lexeme)
+    | IfStmt (Node attr lexeme) (Node attr lexeme) (Maybe (Node attr lexeme))
+    | ForStmt (Node attr lexeme) (Node attr lexeme) (Node attr lexeme) (Node attr lexeme)
+    | WhileStmt (Node attr lexeme) (Node attr lexeme)
+    | DoWhileStmt (Node attr lexeme) (Node attr lexeme)
     | Case (Node attr lexeme) (Node attr lexeme)
     | Default (Node attr lexeme)
     | Label lexeme (Node attr lexeme)
@@ -103,7 +102,7 @@ data Node attr lexeme
     | TyUserDefined lexeme
     -- Functions
     | FunctionDecl Scope (Node attr lexeme) (Maybe (Node attr lexeme))
-    | FunctionDefn Scope (Node attr lexeme) [Node attr lexeme]
+    | FunctionDefn Scope (Node attr lexeme) (Node attr lexeme)
     | FunctionPrototype (Node attr lexeme) lexeme [Node attr lexeme]
     | FunctionParam (Node attr lexeme) (Node attr lexeme)
     | Event lexeme (Node attr lexeme)

--- a/src/Language/Cimple/TraverseAst.hs
+++ b/src/Language/Cimple/TraverseAst.hs
@@ -147,8 +147,6 @@ instance TraverseAst iattr oattr itext otext (Node iattr (Lexeme itext))
             Comment doc <$> recurse start <*> recurse contents <*> recurse end
         CommentBlock comment ->
             CommentBlock <$> recurse comment
-        CommentWord word ->
-            CommentWord <$> recurse word
         Commented comment node ->
             Commented <$> recurse comment <*> recurse node
         ExternC decls ->

--- a/src/Language/Cimple/TreeParser.y
+++ b/src/Language/Cimple/TreeParser.y
@@ -52,7 +52,6 @@ import           Language.Cimple.Lexer (Lexeme)
     copyrightDecl	{ CopyrightDecl{} }
     comment		{ Comment{} }
     commentBlock	{ CommentBlock{} }
-    commentWord		{ CommentWord{} }
     commented		{ Commented{} }
     -- Namespace-like blocks
     externC		{ ExternC{} }

--- a/test/Language/CimpleSpec.hs
+++ b/test/Language/CimpleSpec.hs
@@ -34,14 +34,14 @@ spec = do
                           (L (AlexPn 4 1 5) IdVar "a")
                           [TyStd (L (AlexPn 6 1 7) KwVoid "void")]
                       )
-                      [ Return
+                      (CompoundStmt [ Return
                             (Just
                                 (LiteralExpr
                                     Int
                                     (L (AlexPn 21 1 22) LitInteger "3")
                                 )
                             )
-                      ]
+                      ])
                 ]
 
         it "should parse a type declaration" $ do
@@ -79,7 +79,7 @@ spec = do
             ast `shouldBe` Right
                 [ Comment Regular
                           (L (AlexPn 0 1 1) CmtStart "/*")
-                          [CommentWord (L (AlexPn 3 1 4) CmtWord "hello")]
+                          [L (AlexPn 3 1 4) CmtWord "hello"]
                           (L (AlexPn 9 1 10) CmtEnd "*/")
                 ]
 
@@ -93,13 +93,13 @@ spec = do
                           (L (AlexPn 4 1 5) IdVar "main")
                           []
                       )
-                      [ VarDecl
+                      (CompoundStmt [ VarDecl
                             (TyStd (L (AlexPn 13 1 14) IdStdType "int"))
                             (Declarator
                                 (DeclSpecVar (L (AlexPn 17 1 18) IdVar "a"))
                                 Nothing
                             )
-                      ]
+                      ])
                 ]
 
         it "does not support multiple declarators per declaration" $ do


### PR DESCRIPTION
This makes it easier to identify and distinguish from other Node lists
such as top level decls and struct/union/enum members. I also changed
SwitchStmt to only accept `case` and `default`. Its body is not
considered a CompoundStmt, but rather a list of switch cases. We can do
this now because we enforce that all cases have a single (usually
compound) statement as their body.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/hs-cimple/24)
<!-- Reviewable:end -->
