### PR TITLE
chore: Upgrade to ghc 9.2.1 on github cabal build.

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,5 +1,5 @@
 ---
-cirrus-ci_task:
+bazel-release_task:
   container:
     image: toxchat/toktok-stack:0.0.31-release
     cpu: 2

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -11,7 +11,8 @@ branches:
     protection:
       required_status_checks:
         contexts:
+          - "bazel-release"
           - "build-cabal"
           - "build-stack"
-          - "cirrus-ci"
+          - "check-release"
           - "code-review/reviewable"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,8 +12,8 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-haskell@v1
         with:
-          ghc-version: "8.10.3"
-          cabal-version: "3.2"
+          ghc-version: "9.2.1"
+          cabal-version: "3.6.2.0"
 
       - name: Cache
         uses: actions/cache@v2
@@ -42,6 +42,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-haskell@v1
         with:
+          ghc-version: "9.2.1"
           enable-stack: true
           stack-version: "latest"
 
@@ -53,7 +54,7 @@ jobs:
           path: |
             ~/.stack
             .stack-work
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/*.cabal') }}
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/*.cabal') }}-${{ hashFiles('stack.yaml') }}
           restore-keys: |
             ${{ runner.os }}-build-${{ env.cache-name }}-
             ${{ runner.os }}-build-

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -5,7 +5,10 @@ load("//third_party/haskell/happy:build_defs.bzl", "happy_parser")
 load("//third_party/haskell/hspec-discover:build_defs.bzl", "hspec_test")
 load("//tools/project:build_defs.bzl", "project")
 
-project(custom_github = True)
+project(
+    custom_cirrus = True,
+    custom_github = True,
+)
 
 alex_lexer(
     name = "Lexer",
@@ -36,7 +39,7 @@ happy_parser(
 haskell_library(
     name = "parser",
     srcs = [
-        "src/Language/Cimple/AST.hs",
+        "src/Language/Cimple/Ast.hs",
         "src/Language/Cimple/Parser.hs",
     ],
     src_strip_prefix = "src",
@@ -78,12 +81,12 @@ haskell_library(
     srcs = glob(
         ["src/**/*.*hs"],
         exclude = [
-            "src/Language/Cimple/AST.hs",
+            "src/Language/Cimple/Ast.hs",
             "src/Language/Cimple/Tokens.hs",
         ],
     ),
     src_strip_prefix = "src",
-    version = "0.0.7",
+    version = "0.0.8",
     visibility = ["//visibility:public"],
     deps = [
         ":lexer",

--- a/cimple.cabal
+++ b/cimple.cabal
@@ -1,5 +1,5 @@
 name:                 cimple
-version:              0.0.7
+version:              0.0.8
 synopsis:             Simple C-like programming language
 homepage:             https://toktok.github.io/
 license:              GPL-3
@@ -33,7 +33,7 @@ library
     , Language.Cimple.Program
   other-modules:
       Language.Cimple.Annot
-    , Language.Cimple.AST
+    , Language.Cimple.Ast
     , Language.Cimple.Flatten
     , Language.Cimple.Graph
     , Language.Cimple.Lexer
@@ -115,7 +115,8 @@ test-suite testsuite
   hs-source-dirs: test
   main-is: testsuite.hs
   other-modules:
-      Language.CimpleSpec
+      Language.Cimple.AstSpec
+    , Language.Cimple.ParserSpec
     , Language.Cimple.PrettySpec
   ghc-options:
       -Wall

--- a/src/Language/Cimple.hs
+++ b/src/Language/Cimple.hs
@@ -8,7 +8,7 @@ import           Control.Monad.State.Lazy    (State)
 import           Data.Text                   (Text)
 
 import           Language.Cimple.Annot       as X
-import           Language.Cimple.AST         as X
+import           Language.Cimple.Ast         as X
 import           Language.Cimple.Lexer       as X
 import           Language.Cimple.Parser      as X
 import           Language.Cimple.Tokens      as X

--- a/src/Language/Cimple/Annot.hs
+++ b/src/Language/Cimple/Annot.hs
@@ -18,7 +18,7 @@ import           Data.Functor.Classes         (Eq1, Read1, Show1)
 import           Data.Functor.Classes.Generic (FunctorClassesDefault (..))
 import           Data.Functor.Compose         (Compose (..))
 import           GHC.Generics                 (Generic, Generic1)
-import           Language.Cimple.AST          (Node, NodeF)
+import           Language.Cimple.Ast          (Node, NodeF)
 
 data AnnotF attr a = Annot { attr :: attr, unAnnot :: a }
     deriving (Functor, Generic, Generic1)

--- a/src/Language/Cimple/Ast.hs
+++ b/src/Language/Cimple/Ast.hs
@@ -5,7 +5,7 @@
 {-# LANGUAGE FlexibleInstances  #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE StrictData         #-}
-module Language.Cimple.AST
+module Language.Cimple.Ast
     ( AssignOp (..)
     , BinaryOp (..)
     , UnaryOp (..)

--- a/src/Language/Cimple/Diagnostics.hs
+++ b/src/Language/Cimple/Diagnostics.hs
@@ -13,7 +13,7 @@ import qualified Control.Monad.State.Lazy as State
 import           Data.Fix                 (foldFix)
 import           Data.Text                (Text)
 import qualified Data.Text                as Text
-import           Language.Cimple.AST      (Node)
+import           Language.Cimple.Ast      (Node)
 import qualified Language.Cimple.Flatten  as Flatten
 import           Language.Cimple.Lexer    (Lexeme (..), lexemeLine)
 

--- a/src/Language/Cimple/Flatten.hs
+++ b/src/Language/Cimple/Flatten.hs
@@ -8,7 +8,7 @@ module Language.Cimple.Flatten (lexemes) where
 
 import           Data.Maybe          (maybeToList)
 import           GHC.Generics
-import           Language.Cimple.AST (AssignOp, BinaryOp, CommentStyle,
+import           Language.Cimple.Ast (AssignOp, BinaryOp, CommentStyle,
                                       LiteralType, NodeF (..), Scope, UnaryOp)
 
 class Concats t a where

--- a/src/Language/Cimple/IO.hs
+++ b/src/Language/Cimple/IO.hs
@@ -14,7 +14,7 @@ import qualified Data.Map.Strict                 as Map
 import           Data.Text                       (Text)
 import qualified Data.Text                       as Text
 import qualified Data.Text.Encoding              as Text
-import           Language.Cimple.AST             (Node)
+import           Language.Cimple.Ast             (Node)
 import           Language.Cimple.Lexer           (Lexeme, runAlex)
 import qualified Language.Cimple.Parser          as Parser
 import           Language.Cimple.Program         (Program)

--- a/src/Language/Cimple/Parser.y
+++ b/src/Language/Cimple/Parser.y
@@ -4,7 +4,7 @@ module Language.Cimple.Parser
     ) where
 
 import           Data.Fix               (Fix (..))
-import           Language.Cimple.AST    (AssignOp (..), BinaryOp (..),
+import           Language.Cimple.Ast    (AssignOp (..), BinaryOp (..),
                                          CommentStyle (..), LiteralType (..),
                                          Node, NodeF (..), Scope (..),
                                          UnaryOp (..))

--- a/src/Language/Cimple/Program.hs
+++ b/src/Language/Cimple/Program.hs
@@ -10,7 +10,7 @@ module Language.Cimple.Program
 import           Data.Map.Strict                   (Map)
 import qualified Data.Map.Strict                   as Map
 import           Data.Text                         (Text)
-import           Language.Cimple.AST               (Node)
+import           Language.Cimple.Ast               (Node)
 import           Language.Cimple.Graph             (Graph)
 import qualified Language.Cimple.Graph             as Graph
 import           Language.Cimple.Lexer             (Lexeme (..))

--- a/src/Language/Cimple/SemCheck/Includes.hs
+++ b/src/Language/Cimple/SemCheck/Includes.hs
@@ -9,7 +9,7 @@ import qualified Control.Monad.State.Lazy        as State
 import           Data.Fix                        (Fix (..))
 import           Data.Text                       (Text)
 import qualified Data.Text                       as Text
-import           Language.Cimple.AST             (NodeF (..))
+import           Language.Cimple.Ast             (NodeF (..))
 import           Language.Cimple.Lexer           (Lexeme (..))
 import           Language.Cimple.Tokens          (LexemeClass (..))
 import           Language.Cimple.TranslationUnit (TranslationUnit)

--- a/src/Language/Cimple/TranslationUnit.hs
+++ b/src/Language/Cimple/TranslationUnit.hs
@@ -3,7 +3,7 @@ module Language.Cimple.TranslationUnit
   ( TranslationUnit
   ) where
 
-import           Language.Cimple.AST   (Node)
+import           Language.Cimple.Ast   (Node)
 import           Language.Cimple.Lexer (Lexeme)
 
 type TranslationUnit text = (FilePath, [Node (Lexeme text)])

--- a/src/Language/Cimple/TraverseAst.hs
+++ b/src/Language/Cimple/TraverseAst.hs
@@ -21,7 +21,7 @@ module Language.Cimple.TraverseAst
     ) where
 
 import           Data.Fix              (Fix (..))
-import           Language.Cimple.AST   (Node, NodeF (..))
+import           Language.Cimple.Ast   (Node, NodeF (..))
 import           Language.Cimple.Lexer (Lexeme (..))
 
 class TraverseAst itext otext a where

--- a/src/Language/Cimple/TreeParser.y
+++ b/src/Language/Cimple/TreeParser.y
@@ -8,7 +8,7 @@ module Language.Cimple.TreeParser
 
 import           Data.Fix              (Fix (..))
 import           Data.Text             (Text)
-import           Language.Cimple.AST   (CommentStyle (..), Node, NodeF (..))
+import           Language.Cimple.Ast   (CommentStyle (..), Node, NodeF (..))
 import           Language.Cimple.Lexer (Lexeme)
 }
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,6 +1,3 @@
 ---
 packages: [.]
 resolver: lts-18.18
-extra-deps:
-  - msgpack-binary-0.0.14@sha256:46c3cf9090ad07d45c79cb74a94c05548ce9f2b5e9d78a497de80ceb5bf55014,2383
-  - msgpack-types-0.0.4@sha256:3b045ea90ba9ba62de9538aa7e7915d1356e2cc34ebdb02f4472ee5b981bcab7,1940

--- a/test/Language/Cimple/AstSpec.hs
+++ b/test/Language/Cimple/AstSpec.hs
@@ -1,7 +1,7 @@
 {-# LANGUAGE LambdaCase        #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ViewPatterns      #-}
-module Language.Cimple.ASTSpec where
+module Language.Cimple.AstSpec where
 
 import           Data.Fix             (Fix (..))
 import           Data.Functor.Compose (Compose (..))

--- a/test/Language/Cimple/ParserSpec.hs
+++ b/test/Language/Cimple/ParserSpec.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
-module Language.CimpleSpec where
+module Language.Cimple.ParserSpec where
 
 import           Data.Fix           (Fix (..))
 import           Test.Hspec         (Spec, describe, it, shouldBe)


### PR DESCRIPTION
According to
https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-Readme.md,
GHC 9.2.1 is pre-installed, so we don't need to download it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/hs-cimple/31)
<!-- Reviewable:end -->
