### PR TITLE
cleanup: Make `warn` strict and deprecate `warn'`.

### DIFF
--- a/src/Language/Cimple/Annot.hs
+++ b/src/Language/Cimple/Annot.hs
@@ -1,11 +1,8 @@
-{-# LANGUAGE DeriveFunctor      #-}
-{-# LANGUAGE DeriveGeneric      #-}
-{-# LANGUAGE DeriveTraversable  #-}
-{-# LANGUAGE DerivingVia        #-}
-{-# LANGUAGE FlexibleInstances  #-}
-{-# LANGUAGE StandaloneDeriving #-}
-{-# LANGUAGE StrictData         #-}
-{-# LANGUAGE TypeOperators      #-}
+{-# LANGUAGE DeriveFunctor #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingVia   #-}
+{-# LANGUAGE StrictData    #-}
+{-# LANGUAGE TypeOperators #-}
 module Language.Cimple.Annot
     ( AnnotF (..)
     , AnnotNode

--- a/src/Language/Cimple/Ast.hs
+++ b/src/Language/Cimple/Ast.hs
@@ -1,10 +1,9 @@
-{-# LANGUAGE DeriveFunctor      #-}
-{-# LANGUAGE DeriveGeneric      #-}
-{-# LANGUAGE DeriveTraversable  #-}
-{-# LANGUAGE DerivingVia        #-}
-{-# LANGUAGE FlexibleInstances  #-}
-{-# LANGUAGE StandaloneDeriving #-}
-{-# LANGUAGE StrictData         #-}
+{-# LANGUAGE DeriveFunctor     #-}
+{-# LANGUAGE DeriveGeneric     #-}
+{-# LANGUAGE DeriveTraversable #-}
+{-# LANGUAGE DerivingVia       #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE StrictData        #-}
 module Language.Cimple.Ast
     ( AssignOp (..)
     , BinaryOp (..)

--- a/src/Language/Cimple/Diagnostics.hs
+++ b/src/Language/Cimple/Diagnostics.hs
@@ -3,16 +3,15 @@
 {-# LANGUAGE StrictData        #-}
 module Language.Cimple.Diagnostics
   ( Diagnostics
-  , Diagnostics'
+  , Diagnostics' -- deprecated
   , HasDiagnostics (..)
   , warn
-  , warn'
+  , warn' -- deprecated
   , sloc
   ) where
 
-import           Control.Monad.State.Lazy   (State)
-import qualified Control.Monad.State.Lazy   as State
-import qualified Control.Monad.State.Strict as SState
+import           Control.Monad.State.Strict (State)
+import qualified Control.Monad.State.Strict as State
 import           Data.Fix                   (foldFix)
 import           Data.Text                  (Text)
 import qualified Data.Text                  as Text
@@ -22,19 +21,13 @@ import           Language.Cimple.Lexer      (Lexeme (..), lexemeLine)
 
 type DiagnosticsT diags a = State diags a
 type Diagnostics a = DiagnosticsT [Text] a
+type Diagnostics' a = Diagnostics a
 
-warn
+warn, warn'
     :: (HasLocation at, HasDiagnostics diags)
     => FilePath -> at -> Text -> DiagnosticsT diags ()
 warn file l w = State.modify (addDiagnostic $ sloc file l <> ": " <> w)
-
-type DiagnosticsT' diags a = SState.State diags a
-type Diagnostics' a = DiagnosticsT' [Text] a
-
-warn'
-    :: (HasLocation at, HasDiagnostics diags)
-    => FilePath -> at -> Text -> DiagnosticsT' diags ()
-warn' file l w = SState.modify (addDiagnostic $ sloc file l <> ": " <> w)
+warn' = warn
 
 
 class HasDiagnostics a where

--- a/src/Language/Cimple/IO.hs
+++ b/src/Language/Cimple/IO.hs
@@ -7,7 +7,7 @@ module Language.Cimple.IO
     ) where
 
 import           Control.Monad                   ((>=>))
-import           Control.Monad.State.Lazy        (State, evalState, get, put)
+import           Control.Monad.State.Strict      (State, evalState, get, put)
 import qualified Data.ByteString                 as BS
 import           Data.Map.Strict                 (Map)
 import qualified Data.Map.Strict                 as Map

--- a/src/Language/Cimple/Pretty.hs
+++ b/src/Language/Cimple/Pretty.hs
@@ -366,7 +366,7 @@ ppNode = foldFix go
         ppSemiSep decls <>
         fst elseBranch <$>
         text "#endif"
-    PreprocElse [] -> bare $ empty
+    PreprocElse [] -> bare empty
     PreprocElse decls -> bare $
         linebreak <>
         text "#else" <$>

--- a/src/Language/Cimple/TraverseAst.hs
+++ b/src/Language/Cimple/TraverseAst.hs
@@ -1,8 +1,6 @@
 {-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE InstanceSigs          #-}
-{-# LANGUAGE LambdaCase            #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE NamedFieldPuns        #-}
 {-# LANGUAGE RecordWildCards       #-}
 {-# LANGUAGE ScopedTypeVariables   #-}
 {-# LANGUAGE StrictData            #-}
@@ -150,11 +148,11 @@ instance TraverseAst itext otext (Node (Lexeme itext)) where
         CompoundStmt stmts ->
             Fix <$> (CompoundStmt <$> recurse stmts)
         Break ->
-            Fix <$> (pure Break)
+            pure $ Fix Break
         Goto label ->
             Fix <$> (Goto <$> recurse label)
         Continue ->
-            Fix <$> (pure Continue)
+            pure $ Fix Continue
         Return value ->
             Fix <$> (Return <$> recurse value)
         SwitchStmt value cases ->
@@ -254,7 +252,7 @@ instance TraverseAst itext otext (Node (Lexeme itext)) where
         FunctionParam ty decl ->
             Fix <$> (FunctionParam <$> recurse ty <*> recurse decl)
         Ellipsis ->
-            Fix <$> (pure Ellipsis)
+            pure $ Fix Ellipsis
         ConstDecl ty name ->
             Fix <$> (ConstDecl <$> recurse ty <*> recurse name)
         ConstDefn scope ty name value ->


### PR DESCRIPTION
These are now equivalent.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/hs-cimple/35)
<!-- Reviewable:end -->
