### PR TITLE
refactor: Slightly better AST representation of decls.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -83,7 +83,7 @@ haskell_library(
         ],
     ),
     src_strip_prefix = "src",
-    version = "0.0.8",
+    version = "0.0.9",
     visibility = ["//visibility:public"],
     deps = [
         ":lexer",

--- a/cimple.cabal
+++ b/cimple.cabal
@@ -1,5 +1,5 @@
 name:                 cimple
-version:              0.0.8
+version:              0.0.9
 synopsis:             Simple C-like programming language
 homepage:             https://toktok.github.io/
 license:              GPL-3

--- a/src/Language/Cimple/Ast.hs
+++ b/src/Language/Cimple/Ast.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE DeriveTraversable #-}
 {-# LANGUAGE DerivingVia       #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE Strict            #-}
 {-# LANGUAGE StrictData        #-}
 module Language.Cimple.Ast
     ( AssignOp (..)
@@ -63,10 +64,9 @@ data NodeF lexeme a
     | Label lexeme a
     -- Variable declarations
     | VLA a lexeme a
-    | VarDecl a a
-    | Declarator a (Maybe a)
-    | DeclSpecVar lexeme
-    | DeclSpecArray a (Maybe a)
+    | VarDeclStmt a (Maybe a)
+    | VarDecl a lexeme [a]
+    | DeclSpecArray (Maybe a)
     -- Expressions
     | InitialiserList [a]
     | UnaryExpr UnaryOp a
@@ -93,7 +93,7 @@ data NodeF lexeme a
     | TypedefFunction a
     | Struct lexeme [a]
     | Union lexeme [a]
-    | MemberDecl a a (Maybe lexeme)
+    | MemberDecl a (Maybe lexeme)
     | TyConst a
     | TyPointer a
     | TyStruct lexeme
@@ -104,7 +104,6 @@ data NodeF lexeme a
     | FunctionDecl Scope a
     | FunctionDefn Scope a a
     | FunctionPrototype a lexeme [a]
-    | FunctionParam a a
     | Ellipsis
     -- Constants
     | ConstDecl a lexeme

--- a/src/Language/Cimple/Diagnostics.hs
+++ b/src/Language/Cimple/Diagnostics.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE Strict            #-}
 {-# LANGUAGE StrictData        #-}
 module Language.Cimple.Diagnostics
   ( Diagnostics

--- a/src/Language/Cimple/Flatten.hs
+++ b/src/Language/Cimple/Flatten.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE FlexibleContexts      #-}
 {-# LANGUAGE FlexibleInstances     #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE Strict                #-}
 {-# LANGUAGE StrictData            #-}
 {-# LANGUAGE TypeOperators         #-}
 module Language.Cimple.Flatten (lexemes) where

--- a/src/Language/Cimple/IO.hs
+++ b/src/Language/Cimple/IO.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE Strict     #-}
 {-# LANGUAGE StrictData #-}
 module Language.Cimple.IO
     ( parseFile

--- a/src/Language/Cimple/Lexer.x
+++ b/src/Language/Cimple/Lexer.x
@@ -3,6 +3,7 @@
 {-# LANGUAGE DeriveGeneric      #-}
 {-# LANGUAGE DeriveTraversable  #-}
 {-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE StrictData         #-}
 module Language.Cimple.Lexer
     ( Alex
     , AlexPosn (..)

--- a/src/Language/Cimple/Pretty.hs
+++ b/src/Language/Cimple/Pretty.hs
@@ -308,12 +308,9 @@ ppNode = foldFix go
     CommentExpr   c e -> semi $ fst c <+> fst e
     Ellipsis          -> semi $ text "..."
 
-    Declarator dspec Nothing -> dspec
-    Declarator dspec (Just initr) -> bare $ fst dspec <+> char '=' <+> fst initr
-
-    DeclSpecVar var -> bare $ ppLexeme var
-    DeclSpecArray dspec Nothing     -> bare $ fst dspec <> text "[]"
-    DeclSpecArray dspec (Just dim)  -> bare $ fst dspec <> char '[' <> fst dim <> char ']'
+    VarDecl ty name arrs      -> bare $ fst ty <+> ppLexeme name <> ppSep empty arrs
+    DeclSpecArray Nothing     -> bare $ text "[]"
+    DeclSpecArray (Just dim)  -> bare $ char '[' <> fst dim <> char ']'
 
     TyPointer     ty -> bare $ fst ty <> char '*'
     TyConst       ty -> bare $ fst ty <+> text "const"
@@ -377,7 +374,6 @@ ppNode = foldFix go
         fst elseBranch <$>
         text "#endif"
 
-    FunctionParam ty dspec -> bare $ fst ty <+> fst dspec
     FunctionPrototype ty name params -> bare $
         ppFunctionPrototype ty name params
     FunctionDecl scope proto -> semi $
@@ -385,10 +381,10 @@ ppNode = foldFix go
     FunctionDefn scope proto body -> bare $
         ppScope scope <> fst proto <+> fst body
 
-    MemberDecl ty dspec Nothing -> semi $
-        fst ty <+> fst dspec
-    MemberDecl ty dspec (Just size) -> semi $
-        fst ty <+> fst dspec <+> char ':' <+> ppLexeme size
+    MemberDecl decl Nothing -> semi $
+        fst decl
+    MemberDecl decl (Just size) -> semi $
+        fst decl <+> char ':' <+> ppLexeme size
 
     Struct name members -> semi $
         nest 2 (
@@ -432,22 +428,23 @@ ppNode = foldFix go
         ) <$> text "} " <> ppLexeme ty
 
     -- Statements
-    VarDecl ty declr   -> semi $ fst ty <+> fst declr
-    Return Nothing     -> semi $ text "return"
-    Return (Just e)    -> semi $ text "return" <+> fst e
-    Continue           -> semi $ text "continue"
-    Break              -> semi $ text "break"
-    IfStmt cond t e    -> bare $ ppIfStmt cond t e
-    ForStmt i c n body -> bare $ ppForStmt i c n body
-    Default s          -> cp s $ text "default:" <+> fst s
-    Label l s          -> bare $ ppLexeme l <> char ':' <$> fst s
-    Goto l             -> semi $ text "goto " <> ppLexeme l
-    Case e s           -> cp s $ text "case " <> fst e <> char ':' <+> fst s
-    WhileStmt c body   -> bare $ ppWhileStmt c body
-    DoWhileStmt body c -> semi $ ppDoWhileStmt body c
-    SwitchStmt c body  -> bare $ ppSwitchStmt c body
-    CompoundStmt body  -> bare $ ppCompoundStmt body
-    VLA ty n sz        -> semi $ ppVLA ty n sz
+    VarDeclStmt decl Nothing      -> semi $ fst decl
+    VarDeclStmt decl (Just initr) -> semi $ fst decl <+> char '=' <+> fst initr
+    Return Nothing                -> semi $ text "return"
+    Return (Just e)               -> semi $ text "return" <+> fst e
+    Continue                      -> semi $ text "continue"
+    Break                         -> semi $ text "break"
+    IfStmt cond t e               -> bare $ ppIfStmt cond t e
+    ForStmt i c n body            -> bare $ ppForStmt i c n body
+    Default s                     -> cp s $ text "default:" <+> fst s
+    Label l s                     -> bare $ ppLexeme l <> char ':' <$> fst s
+    Goto l                        -> semi $ text "goto " <> ppLexeme l
+    Case e s                      -> cp s $ text "case " <> fst e <> char ':' <+> fst s
+    WhileStmt c body              -> bare $ ppWhileStmt c body
+    DoWhileStmt body c            -> semi $ ppDoWhileStmt body c
+    SwitchStmt c body             -> bare $ ppSwitchStmt c body
+    CompoundStmt body             -> bare $ ppCompoundStmt body
+    VLA ty n sz                   -> semi $ ppVLA ty n sz
 
 
 ppTranslationUnit :: [Node (Lexeme Text)] -> Doc

--- a/src/Language/Cimple/SemCheck/Includes.hs
+++ b/src/Language/Cimple/SemCheck/Includes.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE Strict     #-}
 {-# LANGUAGE StrictData #-}
 module Language.Cimple.SemCheck.Includes
   ( collectIncludes

--- a/src/Language/Cimple/TraverseAst.hs
+++ b/src/Language/Cimple/TraverseAst.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE RecordWildCards       #-}
 {-# LANGUAGE ScopedTypeVariables   #-}
+{-# LANGUAGE Strict                #-}
 {-# LANGUAGE StrictData            #-}
 {-# LANGUAGE TypeFamilies          #-}
 module Language.Cimple.TraverseAst
@@ -173,14 +174,12 @@ instance TraverseAst itext otext (Node (Lexeme itext)) where
             Fix <$> (Label <$> recurse label <*> recurse stmt)
         VLA ty name size ->
             Fix <$> (VLA <$> recurse ty <*> recurse name <*> recurse size)
-        VarDecl ty decl ->
-            Fix <$> (VarDecl <$> recurse ty <*> recurse decl)
-        Declarator spec value ->
-            Fix <$> (Declarator <$> recurse spec <*> recurse value)
-        DeclSpecVar name ->
-            Fix <$> (DeclSpecVar <$> recurse name)
-        DeclSpecArray spec size ->
-            Fix <$> (DeclSpecArray <$> recurse spec <*> recurse size)
+        VarDeclStmt decl ini ->
+            Fix <$> (VarDeclStmt <$> recurse decl <*> recurse ini)
+        VarDecl ty name arrs ->
+            Fix <$> (VarDecl <$> recurse ty <*> recurse name <*> recurse arrs)
+        DeclSpecArray size ->
+            Fix <$> (DeclSpecArray <$> recurse size)
         InitialiserList values ->
             Fix <$> (InitialiserList <$> recurse values)
         UnaryExpr op expr ->
@@ -229,8 +228,8 @@ instance TraverseAst itext otext (Node (Lexeme itext)) where
             Fix <$> (Struct <$> recurse name <*> recurse members)
         Union name members ->
             Fix <$> (Union <$> recurse name <*> recurse members)
-        MemberDecl ty decl width ->
-            Fix <$> (MemberDecl <$> recurse ty <*> recurse decl <*> recurse width)
+        MemberDecl decl bits ->
+            Fix <$> (MemberDecl <$> recurse decl <*> recurse bits)
         TyConst ty ->
             Fix <$> (TyConst <$> recurse ty)
         TyPointer ty ->
@@ -249,8 +248,6 @@ instance TraverseAst itext otext (Node (Lexeme itext)) where
             Fix <$> (FunctionDefn scope <$> recurse proto <*> recurse body)
         FunctionPrototype ty name params ->
             Fix <$> (FunctionPrototype <$> recurse ty <*> recurse name <*> recurse params)
-        FunctionParam ty decl ->
-            Fix <$> (FunctionParam <$> recurse ty <*> recurse decl)
         Ellipsis ->
             pure $ Fix Ellipsis
         ConstDecl ty name ->

--- a/src/Language/Cimple/TreeParser.y
+++ b/src/Language/Cimple/TreeParser.y
@@ -72,9 +72,8 @@ import           Language.Cimple.Lexer (Lexeme)
     label		{ Fix (Label{}) }
     -- Variable declarations
     vLA			{ Fix (VLA{}) }
+    varDeclStmt		{ Fix (VarDecl{}) }
     varDecl		{ Fix (VarDecl{}) }
-    declarator		{ Fix (Declarator{}) }
-    declSpecVar		{ Fix (DeclSpecVar{}) }
     declSpecArray	{ Fix (DeclSpecArray{}) }
     -- Expressions
     initialiserList	{ Fix (InitialiserList{}) }
@@ -113,7 +112,6 @@ import           Language.Cimple.Lexer (Lexeme)
     functionDecl	{ Fix (FunctionDecl{}) }
     functionDefn	{ Fix (FunctionDefn{}) }
     functionPrototype	{ Fix (FunctionPrototype{}) }
-    functionParam	{ Fix (FunctionParam{}) }
     ellipsis		{ Fix (Ellipsis) }
     -- Constants
     constDecl		{ Fix (ConstDecl{}) }

--- a/test/Language/Cimple/ParserSpec.hs
+++ b/test/Language/Cimple/ParserSpec.hs
@@ -2,12 +2,17 @@
 module Language.Cimple.ParserSpec where
 
 import           Data.Fix           (Fix (..))
-import           Test.Hspec         (Spec, describe, it, shouldBe)
+import           Test.Hspec         (Spec, describe, it, shouldBe,
+                                     shouldSatisfy)
 
-import           Language.Cimple    (AlexPosn (..), CommentStyle (..),
-                                     Lexeme (..), LexemeClass (..),
-                                     LiteralType (..), NodeF (..), Scope (..))
+import           Language.Cimple    (AlexPosn (..), Lexeme (..),
+                                     LexemeClass (..), NodeF (..), Scope (..))
 import           Language.Cimple.IO (parseText)
+
+
+isRight1 :: Either a [b] -> Bool
+isRight1 (Right [_]) = True
+isRight1 _           = False
 
 
 spec :: Spec
@@ -15,83 +20,37 @@ spec = do
     describe "C parsing" $ do
         it "should parse a simple function" $ do
             let ast = parseText "int a(void) { return 3; }"
-            ast `shouldBe` Right
-                [ Fix (FunctionDefn
-                      Global
-                      (Fix (FunctionPrototype
-                          (Fix (TyStd (L (AlexPn 0 1 1) IdStdType "int")))
-                          (L (AlexPn 4 1 5) IdVar "a")
-                          [Fix (TyStd (L (AlexPn 6 1 7) KwVoid "void"))]
-                      ))
-                      (Fix (CompoundStmt [ Fix (Return
-                            (Just
-                                (Fix (LiteralExpr
-                                    Int
-                                    (L (AlexPn 21 1 22) LitInteger "3")
-                                ))
-                            ))
-                      ])))
-                ]
+            ast `shouldSatisfy` isRight1
 
         it "should parse a type declaration" $ do
             let ast = parseText "typedef struct Foo { int x; } Foo;"
-            ast `shouldBe` Right
-                [ Fix (Typedef
-                      (Fix (Struct
-                          (L (AlexPn 15 1 16) IdSueType "Foo")
-                          [ Fix (MemberDecl
-                                (Fix (TyStd (L (AlexPn 21 1 22) IdStdType "int")))
-                                (Fix (DeclSpecVar (L (AlexPn 25 1 26) IdVar "x")))
-                                Nothing)
-                          ]
-                      ))
-                      (L (AlexPn 30 1 31) IdSueType "Foo"))
-                ]
+            ast `shouldSatisfy` isRight1
 
         it "should parse a struct with bit fields" $ do
             let ast = parseText "typedef struct Foo { int x : 123; } Foo;"
-            ast `shouldBe` Right
-                [ Fix (Typedef
-                      (Fix (Struct
-                          (L (AlexPn 15 1 16) IdSueType "Foo")
-                          [ Fix (MemberDecl
-                                (Fix (TyStd (L (AlexPn 21 1 22) IdStdType "int")))
-                                (Fix (DeclSpecVar (L (AlexPn 25 1 26) IdVar "x")))
-                                (Just (L (AlexPn 29 1 30) LitInteger "123")))
-                          ]
-                      ))
-                      (L (AlexPn 36 1 37) IdSueType "Foo"))
-                ]
+            ast `shouldSatisfy` isRight1
 
         it "should parse a comment" $ do
             let ast = parseText "/* hello */"
-            ast `shouldBe` Right
-                [ Fix (Comment Regular
-                          (L (AlexPn 0 1 1) CmtStart "/*")
-                          [L (AlexPn 3 1 4) CmtWord "hello"]
-                          (L (AlexPn 9 1 10) CmtEnd "*/"))
-                ]
+            ast `shouldSatisfy` isRight1
 
         it "supports single declarators" $ do
             let ast = parseText "int main() { int a; }"
             ast `shouldBe` Right
-                [ Fix (FunctionDefn
-                      Global
-                      (Fix (FunctionPrototype
-                          (Fix (TyStd (L (AlexPn 0 1 1) IdStdType "int")))
-                          (L (AlexPn 4 1 5) IdVar "main")
-                          []
-                      ))
-                      (Fix (CompoundStmt [ Fix (VarDecl
-                            (Fix (TyStd (L (AlexPn 13 1 14) IdStdType "int")))
-                            (Fix (Declarator
-                                (Fix (DeclSpecVar (L (AlexPn 17 1 18) IdVar "a")))
-                                Nothing
-                            )))
-                      ])))
+                [ Fix (FunctionDefn Global
+                    (Fix (FunctionPrototype
+                        (Fix (TyStd (L (AlexPn 0 1 1) IdStdType "int")))
+                        (L (AlexPn 4 1 5) IdVar "main")
+                        []))
+                    (Fix (CompoundStmt
+                        [ Fix (VarDeclStmt
+                            (Fix (VarDecl
+                              (Fix (TyStd (L (AlexPn 13 1 14) IdStdType "int")))
+                              (L (AlexPn 17 1 18) IdVar "a")
+                              [])) Nothing)])))
                 ]
 
         it "does not support multiple declarators per declaration" $ do
             let ast = parseText "int main() { int a, b; }"
             ast `shouldBe` Left
-                "1:19: Parse error near PctComma: \",\"; expected one of [\"';'\"]"
+                "1:19: Parse error near PctComma: \",\"; expected one of [\"'='\",\"';'\"]"


### PR DESCRIPTION
This pulls all the type-related information into a single AST node,
making typechecking easier later on. Also, restricted `#ifdef/#ifndef` to
only allow `#else`, no `#elif`. If you want to use `#elif`, use
`#if defined` instead of `#ifdef`. This may make typechecking easier as
well because structs with ifdefs in them can rely on a binary either-or
instead of a complicated conditional for field presence.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/hs-cimple/36)
<!-- Reviewable:end -->
