### PR TITLE
feat: Add `showNode` and `removeSloc` utility functions.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -83,7 +83,7 @@ haskell_library(
         ],
     ),
     src_strip_prefix = "src",
-    version = "0.0.10",
+    version = "0.0.11",
     visibility = ["//visibility:public"],
     deps = [
         ":lexer",

--- a/cimple.cabal
+++ b/cimple.cabal
@@ -1,5 +1,5 @@
 name:                 cimple
-version:              0.0.10
+version:              0.0.11
 synopsis:             Simple C-like programming language
 homepage:             https://toktok.github.io/
 license:              GPL-3

--- a/src/Language/Cimple.hs
+++ b/src/Language/Cimple.hs
@@ -1,10 +1,12 @@
 module Language.Cimple
     ( module X
-    , AstActions
+    , DefaultActions
     , defaultActions
+    , removeSloc
     ) where
 
 import           Control.Monad.State.Strict  (State)
+import qualified Control.Monad.State.Strict  as State
 import           Data.Text                   (Text)
 
 import           Language.Cimple.Annot       as X
@@ -14,7 +16,12 @@ import           Language.Cimple.Parser      as X
 import           Language.Cimple.Tokens      as X
 import           Language.Cimple.TraverseAst as X
 
-type AstActions a = X.IdentityActions (State a) Text
+type DefaultActions a = X.IdentityActions (State a) Text
 
-defaultActions :: AstActions state
+defaultActions :: DefaultActions state
 defaultActions = X.identityActions
+
+removeSloc :: Node (Lexeme Text) -> Node (Lexeme Text)
+removeSloc =
+    flip State.evalState () . traverseAst defaultActions
+        { doLexeme = \_ (L _ c t) _ -> pure $ L (AlexPn 0 0 0) c t }

--- a/src/Language/Cimple/Pretty.hs
+++ b/src/Language/Cimple/Pretty.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE LambdaCase    #-}
 {-# LANGUAGE TupleSections #-}
-module Language.Cimple.Pretty (ppTranslationUnit) where
+module Language.Cimple.Pretty (ppTranslationUnit, showNode) where
 
 import           Data.Fix                     (foldFix)
 import qualified Data.List                    as List
@@ -449,3 +449,6 @@ ppNode = foldFix go
 
 ppTranslationUnit :: [Node (Lexeme Text)] -> Doc
 ppTranslationUnit decls = ppSemiSep (map ppNode decls) <> linebreak
+
+showNode  :: Node (Lexeme Text) -> Text
+showNode = Text.pack . show . fst . ppNode


### PR DESCRIPTION
`showNode` will be used for diagnostics and `removeSloc` is used to
compare nodes without their source location, so e.g. `int i;` is the same
as an `int i;` in another source location.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/hs-cimple/38)
<!-- Reviewable:end -->
