### PR TITLE
feat: Preliminary support for doxygen groups.

### DIFF
--- a/src/Language/Cimple/Ast.hs
+++ b/src/Language/Cimple/Ast.hs
@@ -44,7 +44,7 @@ data NodeF lexeme a
     | LicenseDecl lexeme [a]
     | CopyrightDecl lexeme (Maybe lexeme) [lexeme]
     | Comment CommentStyle lexeme [lexeme] lexeme
-    | CommentBlock lexeme
+    | CommentSectionEnd lexeme
     | Commented a a
     -- Namespace-like blocks
     | ExternC [a]

--- a/src/Language/Cimple/Lexer.x
+++ b/src/Language/Cimple/Lexer.x
@@ -106,6 +106,8 @@ tokens :-
 <0>		"//!TOKSTYLE-"				{ start ignoreSC }
 <0>		"/*"					{ mkL CmtStart `andBegin` cmtSC }
 <0>		"/**"					{ mkL CmtStartDoc `andBegin` cmtSC }
+<0>		"/** @{"				{ mkL CmtStartDocSection `andBegin` cmtSC }
+<0>		"/** @} */"				{ mkL CmtEndDocSection }
 <0>		"/**""*"+				{ mkL CmtStartBlock `andBegin` cmtSC }
 <0,cmtSC>	\"(\\.|[^\"])*\"			{ mkL LitString }
 <0>		'(\\|[^'])*'				{ mkL LitChar }

--- a/src/Language/Cimple/MapAst.hs
+++ b/src/Language/Cimple/MapAst.hs
@@ -140,8 +140,8 @@ instance MapAst itext otext (Node (Lexeme itext)) where
             Fix <$> (CopyrightDecl <$> recurse from <*> recurse to <*> recurse owner)
         Comment doc start contents end ->
             Fix <$> (Comment doc <$> recurse start <*> recurse contents <*> recurse end)
-        CommentBlock comment ->
-            Fix <$> (CommentBlock <$> recurse comment)
+        CommentSectionEnd comment ->
+            Fix <$> (CommentSectionEnd <$> recurse comment)
         Commented comment subject ->
             Fix <$> (Commented <$> recurse comment <*> recurse subject)
         ExternC decls ->

--- a/src/Language/Cimple/Parser.y
+++ b/src/Language/Cimple/Parser.y
@@ -115,9 +115,10 @@ import           Language.Cimple.Tokens (LexemeClass (..))
     '#include'			{ L _ PpInclude			_ }
     '#undef'			{ L _ PpUndef			_ }
     '\n'			{ L _ PpNewline			_ }
-    '/**/'			{ L _ CmtBlock			_ }
     '/*'			{ L _ CmtStart			_ }
     '/**'			{ L _ CmtStartDoc		_ }
+    '/** @{'			{ L _ CmtStartDocSection	_ }
+    '/** @} */'			{ L _ CmtEndDocSection		_ }
     '/***'			{ L _ CmtStartBlock		_ }
     ' * '			{ L _ CmtIndent			_ }
     '*/'			{ L _ CmtEnd			_ }
@@ -201,8 +202,9 @@ Comment :: { StringNode }
 Comment
 :	'/*' CommentTokens '*/'					{ Fix $ Comment Regular $1 (reverse $2) $3 }
 |	'/**' CommentTokens '*/'				{ Fix $ Comment Doxygen $1 (reverse $2) $3 }
+|	'/** @{' CommentTokens '*/'				{ Fix $ Comment Block $1 (reverse $2) $3 }
 |	'/***' CommentTokens '*/'				{ Fix $ Comment Block $1 (reverse $2) $3 }
-|	'/**/'							{ Fix $ CommentBlock $1 }
+|	'/** @} */'						{ Fix $ CommentSectionEnd $1 }
 
 CommentTokens :: { [StringLexeme] }
 CommentTokens

--- a/src/Language/Cimple/Pretty.hs
+++ b/src/Language/Cimple/Pretty.hs
@@ -252,7 +252,7 @@ ppNode = foldFix go
 
     Comment style _ cs e -> bare $
         ppComment style cs e
-    CommentBlock cs -> bare $
+    CommentSectionEnd cs -> bare $
         ppLexeme cs
     Commented (c, _) (d, s) -> (, s) $
         c <$> d

--- a/src/Language/Cimple/Tokens.hs
+++ b/src/Language/Cimple/Tokens.hs
@@ -100,10 +100,12 @@ data LexemeClass
     | PpNewline
     | PpUndef
     | CmtBlock
+    | CmtEndDocSection
     | CmtIndent
     | CmtStart
     | CmtStartBlock
     | CmtStartDoc
+    | CmtStartDocSection
     | CmtSpdxCopyright
     | CmtSpdxLicense
     | CmtCode

--- a/src/Language/Cimple/TraverseAst.hs
+++ b/src/Language/Cimple/TraverseAst.hs
@@ -159,7 +159,7 @@ instance TraverseAst text (Node (Lexeme text)) where
             _ <- recurse contents
             _ <- recurse end
             pure ()
-        CommentBlock comment -> do
+        CommentSectionEnd comment -> do
             _ <- recurse comment
             pure ()
         Commented comment subject -> do

--- a/src/Language/Cimple/TreeParser.y
+++ b/src/Language/Cimple/TreeParser.y
@@ -52,7 +52,7 @@ import           Language.Cimple.Lexer (Lexeme)
     licenseDecl		{ Fix (LicenseDecl{}) }
     copyrightDecl	{ Fix (CopyrightDecl{}) }
     comment		{ Fix (Comment{}) }
-    commentBlock	{ Fix (CommentBlock{}) }
+    commentSectionEnd	{ Fix (CommentSectionEnd{}) }
     commented		{ Fix (Commented{}) }
     -- Namespace-like blocks
     externC		{ Fix (ExternC{}) }
@@ -173,6 +173,7 @@ DeclList
 Decl :: { TextNode }
 Decl
 :	comment							{ $1 }
+|	commentSectionEnd					{ $1 }
 |	CommentableDecl						{ $1 }
 |	docComment CommentableDecl				{ Fix $ Commented $1 $2 }
 


### PR DESCRIPTION
Doxygen groups are marked by `@{` and `@}`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/hs-cimple/50)
<!-- Reviewable:end -->
