### PR TITLE
cleanup: Simplify pretty-printer.

### DIFF
--- a/src/Language/Cimple/Ast.hs
+++ b/src/Language/Cimple/Ast.hs
@@ -62,6 +62,7 @@ data NodeF lexeme a
     | Case a a
     | Default a
     | Label lexeme a
+    | ExprStmt a
     -- Variable declarations
     | VLA a lexeme a
     | VarDeclStmt a (Maybe a)
@@ -89,6 +90,7 @@ data NodeF lexeme a
     | EnumConsts (Maybe lexeme) [a]
     | EnumDecl lexeme [a] lexeme
     | Enumerator lexeme (Maybe a)
+    | AggregateDecl a
     | Typedef a lexeme
     | TypedefFunction a
     | Struct lexeme [a]

--- a/src/Language/Cimple/MapAst.hs
+++ b/src/Language/Cimple/MapAst.hs
@@ -172,6 +172,8 @@ instance MapAst itext otext (Node (Lexeme itext)) where
             Fix <$> (Default <$> recurse stmt)
         Label label stmt ->
             Fix <$> (Label <$> recurse label <*> recurse stmt)
+        ExprStmt expr ->
+            Fix <$> (ExprStmt <$> recurse expr)
         VLA ty name size ->
             Fix <$> (VLA <$> recurse ty <*> recurse name <*> recurse size)
         VarDeclStmt decl ini ->
@@ -220,6 +222,8 @@ instance MapAst itext otext (Node (Lexeme itext)) where
             Fix <$> (EnumDecl <$> recurse name <*> recurse members <*> recurse tyName)
         Enumerator name value ->
             Fix <$> (Enumerator <$> recurse name <*> recurse value)
+        AggregateDecl struct ->
+            Fix <$> (AggregateDecl <$> recurse struct)
         Typedef ty name ->
             Fix <$> (Typedef <$> recurse ty <*> recurse name)
         TypedefFunction ty ->

--- a/src/Language/Cimple/Parser.y
+++ b/src/Language/Cimple/Parser.y
@@ -325,9 +325,9 @@ Stmt
 |	ForStmt							{ $1 }
 |	WhileStmt						{ $1 }
 |	DoWhileStmt						{ $1 }
-|	AssignExpr ';'						{ $1 }
-|	ExprStmt ';'						{ $1 }
-|	FunctionCall ';'					{ $1 }
+|	AssignExpr ';'						{ Fix $ ExprStmt $1 }
+|	ExprStmt ';'						{ Fix $ ExprStmt $1 }
+|	FunctionCall ';'					{ Fix $ ExprStmt $1 }
 |	break ';'						{ Fix $ Break }
 |	goto ID_CONST ';'					{ Fix $ Goto $2 }
 |	ID_CONST ':' Stmt					{ Fix $ Label $1 $3 }
@@ -349,7 +349,7 @@ ForStmt
 
 ForInit :: { StringNode }
 ForInit
-:	AssignExpr ';'						{ $1 }
+:	AssignExpr ';'						{ Fix $ ExprStmt $1 }
 |	VarDeclStmt						{ $1 }
 
 ForNext :: { StringNode }
@@ -572,7 +572,7 @@ EnumeratorName
 
 AggregateDecl :: { StringNode }
 AggregateDecl
-:	AggregateType ';'					{ $1 }
+:	AggregateType ';'					{ Fix $ AggregateDecl $1 }
 |	typedef AggregateType ID_SUE_TYPE ';'			{ Fix $ Typedef $2 $3 }
 
 AggregateType :: { StringNode }

--- a/src/Language/Cimple/TraverseAst.hs
+++ b/src/Language/Cimple/TraverseAst.hs
@@ -216,6 +216,9 @@ instance TraverseAst text (Node (Lexeme text)) where
             _ <- recurse label
             _ <- recurse stmt
             pure ()
+        ExprStmt expr -> do
+            _ <- recurse expr
+            pure ()
         VLA ty name size -> do
             _ <- recurse ty
             _ <- recurse name
@@ -307,6 +310,9 @@ instance TraverseAst text (Node (Lexeme text)) where
         Enumerator name value -> do
             _ <- recurse name
             _ <- recurse value
+            pure ()
+        AggregateDecl struct -> do
+            _ <- recurse struct
             pure ()
         Typedef ty name -> do
             _ <- recurse ty

--- a/src/Language/Cimple/TreeParser.y
+++ b/src/Language/Cimple/TreeParser.y
@@ -70,6 +70,7 @@ import           Language.Cimple.Lexer (Lexeme)
     case		{ Fix (Case{}) }
     default		{ Fix (Default{}) }
     label		{ Fix (Label{}) }
+    exprStmt		{ Fix (ExprStmt{}) }
     -- Variable declarations
     vLA			{ Fix (VLA{}) }
     varDeclStmt		{ Fix (VarDecl{}) }
@@ -97,6 +98,7 @@ import           Language.Cimple.Lexer (Lexeme)
     enumConsts		{ Fix (EnumConsts{}) }
     enumDecl		{ Fix (EnumDecl{}) }
     enumerator		{ Fix (Enumerator{}) }
+    aggregateDecl	{ Fix (AggregateDecl{}) }
     typedef		{ Fix (Typedef{}) }
     typedefFunction	{ Fix (TypedefFunction{}) }
     struct		{ Fix (Struct{}) }
@@ -181,6 +183,7 @@ CommentableDecl :: { TextNode }
 CommentableDecl
 :	functionDecl						{ $1 }
 |	functionDefn						{ $1 }
+|	aggregateDecl						{ $1 }
 |	struct							{ $1 }
 |	typedef							{ $1 }
 |	constDecl						{ $1 }

--- a/tools/cimplefmt.hs
+++ b/tools/cimplefmt.hs
@@ -32,9 +32,9 @@ processFile flags source = do
     case ast of
         Left err -> fail err
         Right (_, ok) ->
-            if "--reparse" `elem` flags
-               then reparseText $ format ok
-               else BS.putStr . Text.encodeUtf8 . format $ ok
+            if "--no-reparse" `elem` flags
+               then BS.putStr . Text.encodeUtf8 . format $ ok
+               else reparseText $ format ok
 
 
 main :: IO ()


### PR DESCRIPTION
By recording semicolons in the AST, we don't need to go out of our way
to recover this information in the pretty-printer. Now the
pretty-printer is a nice simple function of `Ast -> Doc` for any given
node without context.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/hs-cimple/51)
<!-- Reviewable:end -->
