### PR TITLE
feat: Some extensions to the syntax.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -27,6 +27,20 @@ haskell_library(
     ],
 )
 
+haskell_library(
+    name = "ast",
+    srcs = ["src/Language/Cimple/Ast.hs"],
+    src_strip_prefix = "src",
+    visibility = ["//hs-cimple:__subpackages__"],
+    deps = [
+        ":lexer",
+        hazel_library("aeson"),
+        hazel_library("base"),
+        hazel_library("data-fix"),
+        hazel_library("transformers-compat"),
+    ],
+)
+
 happy_parser(
     name = "Parser",
     src = "src/Language/Cimple/Parser.y",
@@ -35,13 +49,11 @@ happy_parser(
 
 haskell_library(
     name = "parser",
-    srcs = [
-        "src/Language/Cimple/Ast.hs",
-        "src/Language/Cimple/Parser.hs",
-    ],
+    srcs = [":Parser"],
     src_strip_prefix = "src",
     visibility = ["//hs-cimple:__subpackages__"],
     deps = [
+        ":ast",
         ":lexer",
         hazel_library("aeson"),
         hazel_library("array"),
@@ -60,12 +72,12 @@ happy_parser(
 
 haskell_library(
     name = "tree_parser",
-    srcs = ["src/Language/Cimple/TreeParser.hs"],
+    srcs = [":TreeParser"],
     src_strip_prefix = "src",
     visibility = ["//hs-cimple:__subpackages__"],
     deps = [
+        ":ast",
         ":lexer",
-        ":parser",
         hazel_library("array"),
         hazel_library("base"),
         hazel_library("data-fix"),
@@ -86,6 +98,7 @@ haskell_library(
     version = "0.0.15",
     visibility = ["//visibility:public"],
     deps = [
+        ":ast",
         ":lexer",
         ":parser",
         ":tree_parser",

--- a/src/Language/Cimple/Ast.hs
+++ b/src/Language/Cimple/Ast.hs
@@ -18,7 +18,7 @@ module Language.Cimple.Ast
 import           Data.Aeson                   (FromJSON, FromJSON1, ToJSON,
                                                ToJSON1)
 import           Data.Fix                     (Fix)
-import           Data.Functor.Classes         (Eq1, Read1, Show1)
+import           Data.Functor.Classes         (Eq1, Ord1, Read1, Show1)
 import           Data.Functor.Classes.Generic (FunctorClassesDefault (..))
 import           GHC.Generics                 (Generic, Generic1)
 
@@ -104,6 +104,7 @@ data NodeF lexeme a
     | TyStd lexeme
     | TyUserDefined lexeme
     -- Functions
+    | AttrPrintf lexeme lexeme a
     | FunctionDecl Scope a
     | FunctionDefn Scope a a
     | FunctionPrototype a lexeme [a]
@@ -113,8 +114,8 @@ data NodeF lexeme a
     -- Constants
     | ConstDecl a lexeme
     | ConstDefn Scope a lexeme a
-    deriving (Show, Read, Eq, Generic, Generic1, Functor, Foldable, Traversable)
-    deriving (Show1, Read1, Eq1) via FunctorClassesDefault (NodeF lexeme)
+    deriving (Show, Read, Eq, Ord, Generic, Generic1, Functor, Foldable, Traversable)
+    deriving (Show1, Read1, Eq1, Ord1) via FunctorClassesDefault (NodeF lexeme)
 
 type Node lexeme = Fix (NodeF lexeme)
 
@@ -133,7 +134,7 @@ data AssignOp
     | AopMod
     | AopLsh
     | AopRsh
-    deriving (Show, Read, Eq, Generic)
+    deriving (Enum, Bounded, Ord, Show, Read, Eq, Generic)
 
 instance FromJSON AssignOp
 instance ToJSON AssignOp
@@ -157,7 +158,7 @@ data BinaryOp
     | BopGt
     | BopGe
     | BopRsh
-    deriving (Show, Read, Eq, Generic)
+    deriving (Enum, Bounded, Ord, Show, Read, Eq, Generic)
 
 instance FromJSON BinaryOp
 instance ToJSON BinaryOp
@@ -170,7 +171,7 @@ data UnaryOp
     | UopDeref
     | UopIncr
     | UopDecr
-    deriving (Show, Read, Eq, Generic)
+    deriving (Enum, Bounded, Ord, Show, Read, Eq, Generic)
 
 instance FromJSON UnaryOp
 instance ToJSON UnaryOp
@@ -181,7 +182,7 @@ data LiteralType
     | Bool
     | String
     | ConstId
-    deriving (Show, Read, Eq, Generic)
+    deriving (Enum, Bounded, Ord, Show, Read, Eq, Generic)
 
 instance FromJSON LiteralType
 instance ToJSON LiteralType
@@ -189,7 +190,7 @@ instance ToJSON LiteralType
 data Scope
     = Global
     | Static
-    deriving (Show, Read, Eq, Generic)
+    deriving (Enum, Bounded, Ord, Show, Read, Eq, Generic)
 
 instance FromJSON Scope
 instance ToJSON Scope
@@ -197,8 +198,10 @@ instance ToJSON Scope
 data CommentStyle
     = Regular
     | Doxygen
+    | Section
     | Block
-    deriving (Show, Read, Eq, Generic)
+    | Ignore
+    deriving (Enum, Bounded, Ord, Show, Read, Eq, Generic)
 
 instance FromJSON CommentStyle
 instance ToJSON CommentStyle

--- a/src/Language/Cimple/MapAst.hs
+++ b/src/Language/Cimple/MapAst.hs
@@ -248,6 +248,8 @@ instance MapAst itext otext (Node (Lexeme itext)) where
             Fix <$> (TyStd <$> recurse name)
         TyUserDefined name ->
             Fix <$> (TyUserDefined <$> recurse name)
+        AttrPrintf fmt ellipsis fun ->
+            Fix <$> (AttrPrintf <$> recurse fmt <*> recurse ellipsis <*> recurse fun)
         FunctionDecl scope proto ->
             Fix <$> (FunctionDecl scope <$> recurse proto)
         FunctionDefn scope proto body ->

--- a/src/Language/Cimple/Tokens.hs
+++ b/src/Language/Cimple/Tokens.hs
@@ -23,6 +23,7 @@ data LexemeClass
     | KwEnum
     | KwExtern
     | KwFor
+    | KwGnuPrintf
     | KwGoto
     | KwIf
     | KwNonNull
@@ -115,10 +116,13 @@ data LexemeClass
     | CmtWord
     | CmtRef
     | CmtEnd
+    | IgnStart
+    | IgnBody
+    | IgnEnd
 
     | Error
     | Eof
-    deriving (Show, Eq, Generic, Ord)
+    deriving (Enum, Bounded, Ord, Eq, Show, Generic)
 
 instance FromJSON LexemeClass
 instance ToJSON LexemeClass

--- a/src/Language/Cimple/TraverseAst.hs
+++ b/src/Language/Cimple/TraverseAst.hs
@@ -327,6 +327,11 @@ instance TraverseAst text (Node (Lexeme text)) where
             recurse name
         TyUserDefined name ->
             recurse name
+        AttrPrintf fmt ellipsis fun -> do
+            _ <- recurse fmt
+            _ <- recurse ellipsis
+            _ <- recurse fun
+            pure ()
         FunctionDecl _scope proto ->
             recurse proto
         FunctionDefn _scope proto body -> do

--- a/tools/cimplefmt.hs
+++ b/tools/cimplefmt.hs
@@ -3,16 +3,15 @@ module Main (main) where
 import qualified Data.ByteString        as BS
 import           Data.List              (isPrefixOf)
 import           Data.Text              (Text)
-import qualified Data.Text              as Text
 import qualified Data.Text.Encoding     as Text
 import           Language.Cimple        (Lexeme, Node)
 import           Language.Cimple.IO     (parseFile, parseText)
-import           Language.Cimple.Pretty (plain, ppTranslationUnit)
+import           Language.Cimple.Pretty (plain, ppTranslationUnit, render)
 import           System.Environment     (getArgs)
 
 
 format :: Bool -> [Node (Lexeme Text)] -> Text
-format color = Text.pack . show . maybePlain . ppTranslationUnit
+format color = render . maybePlain . ppTranslationUnit
   where
     maybePlain = if color then id else plain
 
@@ -34,9 +33,9 @@ processFile flags source = do
     case ast of
         Left err -> fail err
         Right (_, ok) ->
-            if "--no-reparse" `elem` flags
-               then BS.putStr . Text.encodeUtf8 . format True $ ok
-               else reparseText $ format False ok
+            if "--reparse" `elem` flags
+               then reparseText $ format False ok
+               else BS.putStr . Text.encodeUtf8 . format True $ ok
 
 
 main :: IO ()


### PR DESCRIPTION
Summary:
- `static_assert` is now allowed inside functions.
- `sizeof` can now contain any expression, not just constant expressions. E.g. `sizeof(++*foo)` is allowed in principle in the syntax. Tokstyle may later check this for sanity, but we want to use `static_assert(sizeof(expr) == sizeof(other_expr), ...)` with non-constexprs.
- Tokstyle exclusions are now recorded as comments so we can reproduce them in pretty-printing.
- `GNU_PRINTF` is now supported in the AST.
- Multi-line macro body printing now works correctly (with escape at eol).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/hs-cimple/62)
<!-- Reviewable:end -->
