### PR TITLE
fix: Don't create empty groups for empty list of feature defines.

### DIFF
--- a/src/Language/Cimple/Pretty.hs
+++ b/src/Language/Cimple/Pretty.hs
@@ -427,7 +427,7 @@ ppNode = foldFix go
     IfStmt cond t e               -> ppIfStmt cond t e
     ForStmt i c n body            -> ppForStmt i c n body
     Default s                     -> kwDefault <> colon <+> s
-    Label l s                     -> ppLexeme l <> colon <$> s
+    Label l s                     -> indent (-99) (line <> ppLexeme l <> colon) <$> s
     ExprStmt e                    -> e <> semi
     Goto l                        -> kwGoto <+> ppLexeme l <> semi
     Case e s                      -> kwCase <+> e <> colon <+> s

--- a/src/Language/Cimple/TreeParser.y
+++ b/src/Language/Cimple/TreeParser.y
@@ -8,6 +8,7 @@ module Language.Cimple.TreeParser
     ) where
 
 import           Data.Fix                    (Fix (..))
+import           Data.Maybe                  (maybeToList)
 import           Data.Text                   (Text)
 import qualified Data.Text                   as Text
 import           Language.Cimple.Ast         (CommentStyle (..), Node,
@@ -145,12 +146,12 @@ HeaderBody
 
 Source :: { [NonTerm] }
 Source
-:	Features localInclude Includes Decls			{ [Fix (Group $1), $2] ++ $3 ++ $4 }
+:	Features localInclude Includes Decls			{ maybeToList $1 ++ [$2] ++ $3 ++ $4 }
 
-Features :: { [NonTerm] }
+Features :: { Maybe NonTerm }
 Features
-:								{ [] }
-|	Features IfDefine					{ $2 : $1 }
+:								{ Nothing }
+|	NonEmptyList(IfDefine)					{ Just $ Fix $ Group $1 }
 
 IfDefine :: { NonTerm }
 IfDefine


### PR DESCRIPTION
This would create a lot of whitespace before the module include.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/hs-cimple/66)
<!-- Reviewable:end -->
