### PR TITLE
chore: Remove `groom` dependency in cimple.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -155,7 +155,6 @@ haskell_library(
         hazel_library("containers"),
         hazel_library("data-fix"),
         hazel_library("filepath"),
-        hazel_library("groom"),
         hazel_library("monad-parallel"),
         hazel_library("mtl"),
         hazel_library("split"),

--- a/cimple.cabal
+++ b/cimple.cabal
@@ -56,7 +56,6 @@ library
     , containers
     , data-fix
     , filepath
-    , groom
     , monad-parallel
     , mtl
     , recursion-schemes


### PR DESCRIPTION
We're not using it and it's quite a heavy dependency.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/hs-cimple/75)
<!-- Reviewable:end -->
