### PR TITLE
cleanup: Add "etc." to the list of words.

### DIFF
--- a/src/Language/Cimple/Lexer.x
+++ b/src/Language/Cimple/Lexer.x
@@ -243,6 +243,7 @@ tokens :-
 <cmtSC>		[A-Z][A-Za-z]+"::"[a-z_]+		{ mkL CmtWord }
 <cmtSC>		"E.g."					{ mkL CmtWord }
 <cmtSC>		"e.g."					{ mkL CmtWord }
+<cmtSC>		"etc."					{ mkL CmtWord }
 <cmtSC>		"I.e."					{ mkL CmtWord }
 <cmtSC>		"i.e."					{ mkL CmtWord }
 <cmtSC>		[0-2][0-9](":"[0-5][0-9]){2}"."[0-9]{3}	{ mkL CmtWord }


### PR DESCRIPTION
Since it ends in `'.'` the current parser struggles with it otherwise.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/hs-cimple/76)
<!-- Reviewable:end -->
