### PR TITLE
feat: Add support for private/extends/implements.

### DIFF
--- a/src/Language/Cimple/Ast.hs
+++ b/src/Language/Cimple/Ast.hs
@@ -138,10 +138,14 @@ data CommentF lexeme a
     | DocAttention [a]
     | DocBrief [a]
     | DocDeprecated [a]
+    | DocExtends lexeme
+    | DocImplements lexeme
     | DocParam (Maybe lexeme) lexeme [a]
     | DocReturn [a]
     | DocRetval lexeme [a]
     | DocSee lexeme [a]
+
+    | DocPrivate
 
     | DocParagraph [a]
     | DocLine [a]

--- a/src/Language/Cimple/CommentParser.y
+++ b/src/Language/Cimple/CommentParser.y
@@ -28,8 +28,10 @@ import           Language.Cimple.Tokens      (LexemeClass (..))
     '@attention'		{ L _ CmtCommand "@attention"	}
     '@brief'			{ L _ CmtCommand "@brief"	}
     '@deprecated'		{ L _ CmtCommand "@deprecated"	}
+    '@extends'			{ L _ CmtCommand "@extends"	}
     '@implements'		{ L _ CmtCommand "@implements"	}
     '@param'			{ L _ CmtCommand "@param"	}
+    '@private'			{ L _ CmtCommand "@private"	}
     '@ref'			{ L _ CmtCommand "@ref"		}
     '@p'			{ L _ CmtCommand "@p"		}
     '@return'			{ L _ CmtCommand "@return"	}
@@ -137,6 +139,9 @@ Command(x)
 |	'@return' '\n' BulletListItemII				{ Fix $ DocReturn (Fix (DocLine []) : $3) }
 |	'@see' CMT_WORD x					{ Fix $ DocSee $2 $3 }
 |	'@deprecated' x						{ Fix $ DocDeprecated $2 }
+|	'@implements' CMT_WORD					{ Fix $ DocImplements $2 }
+|	'@extends' CMT_WORD					{ Fix $ DocExtends $2 }
+|	'@private'						{ Fix DocPrivate }
 
 BulletListItem :: { NonTerm }
 BulletListItem

--- a/src/Language/Cimple/MapAst.hs
+++ b/src/Language/Cimple/MapAst.hs
@@ -122,6 +122,10 @@ instance MapAst itext otext (Comment (Lexeme itext)) where
             Fix <$> (DocBrief <$> recurse docs)
         DocDeprecated docs ->
             Fix <$> (DocDeprecated <$> recurse docs)
+        DocExtends feat ->
+            Fix <$> (DocExtends <$> recurse feat)
+        DocImplements feat ->
+            Fix <$> (DocImplements <$> recurse feat)
         DocParam attr name docs ->
             Fix <$> (DocParam <$> recurse attr <*> recurse name <*> recurse docs)
         DocReturn docs ->
@@ -130,6 +134,8 @@ instance MapAst itext otext (Comment (Lexeme itext)) where
             Fix <$> (DocRetval <$> recurse expr <*> recurse docs)
         DocSee ref docs ->
             Fix <$> (DocSee <$> recurse ref <*> recurse docs)
+
+        DocPrivate -> pure $ Fix DocPrivate
 
         DocParagraph docs ->
             Fix <$> (DocParagraph <$> recurse docs)

--- a/src/Language/Cimple/Pretty.hs
+++ b/src/Language/Cimple/Pretty.hs
@@ -53,7 +53,10 @@ kwWhile         = dullred   $ text "while"
 kwDocAttention  = dullcyan $ text "@attention"
 kwDocBrief      = dullcyan $ text "@brief"
 kwDocDeprecated = dullcyan $ text "@deprecated"
+kwDocExtends    = dullcyan $ text "@extends"
+kwDocImplements = dullcyan $ text "@implements"
 kwDocParam      = dullcyan $ text "@param"
+kwDocPrivate    = dullcyan $ text "@private"
 kwDocRef        = dullcyan $ text "@ref"
 kwDocReturn     = dullcyan $ text "@return"
 kwDocRetval     = dullcyan $ text "@retval"
@@ -298,6 +301,9 @@ ppCommentInfo = foldFix go
     DocSee name docs    -> kwDocSee        <+> ppRef name <+> ppIndented docs
     DocRef name         -> kwDocRef        <+> ppRef name
     DocP name           -> kwDocP          <+> ppRef name
+    DocExtends feat     -> kwDocExtends    <+> ppLexeme feat
+    DocImplements feat  -> kwDocImplements <+> ppLexeme feat
+    DocPrivate          -> kwDocPrivate
 
     DocParagraph docs -> ppIndented docs
     DocLine docs -> fillSep docs

--- a/src/Language/Cimple/TraverseAst.hs
+++ b/src/Language/Cimple/TraverseAst.hs
@@ -107,6 +107,10 @@ instance TraverseAst text (Comment (Lexeme text)) where
             recurse docs
         DocDeprecated docs ->
             recurse docs
+        DocExtends feat ->
+            recurse feat
+        DocImplements feat ->
+            recurse feat
         DocParam attr name docs -> do
             _ <- recurse attr
             _ <- recurse name
@@ -122,6 +126,8 @@ instance TraverseAst text (Comment (Lexeme text)) where
             _ <- recurse ref
             _ <- recurse docs
             pure ()
+
+        DocPrivate -> pure ()
 
         DocParagraph docs ->
             recurse docs


### PR DESCRIPTION
`@private` will be used to ensure a function is used only inside the .c
file corresponding to the .h file. `@extends` and `@implements` will be
used for generated code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/toktok/hs-cimple/77)
<!-- Reviewable:end -->
