### PR TITLE
cleanup: Remove Ord instance from Lexeme.

### DIFF
--- a/src/Language/Cimple/Lexer.x
+++ b/src/Language/Cimple/Lexer.x
@@ -296,13 +296,12 @@ tokens :-
 <0,ppSC,cmtSC,codeSC>	.				{ mkL ErrorToken }
 
 {
-deriving instance Ord AlexPosn
 deriving instance Generic AlexPosn
 instance FromJSON AlexPosn
 instance ToJSON AlexPosn
 
 data Lexeme text = L AlexPosn LexemeClass text
-    deriving (Ord, Eq, Show, Generic, Functor, Foldable, Traversable)
+    deriving (Eq, Show, Generic, Functor, Foldable, Traversable)
 
 instance FromJSON text => FromJSON (Lexeme text)
 instance ToJSON text => ToJSON (Lexeme text)


### PR DESCRIPTION
We don't need it, and it conflicts with later alex versions.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/hs-cimple/85)
<!-- Reviewable:end -->
