### PR TITLE
chore: Disable targets for cross-compilation.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -19,6 +19,7 @@ haskell_library(
         "src/Language/Cimple/Tokens.hs",
     ],
     src_strip_prefix = "src",
+    tags = ["no-cross"],
     visibility = [
         "//hs-cimple:__subpackages__",
         "//tools/haskell:__pkg__",
@@ -36,6 +37,7 @@ haskell_library(
     name = "ast",
     srcs = ["src/Language/Cimple/Ast.hs"],
     src_strip_prefix = "src",
+    tags = ["no-cross"],
     visibility = [
         "//hs-cimple:__subpackages__",
         "//tools/haskell:__pkg__",
@@ -55,6 +57,7 @@ haskell_library(
         "src/Language/Cimple/Flatten.hs",
     ],
     src_strip_prefix = "src",
+    tags = ["no-cross"],
     visibility = [
         "//hs-cimple:__subpackages__",
         "//tools/haskell:__pkg__",
@@ -79,6 +82,7 @@ haskell_library(
     name = "parser",
     srcs = [":Parser"],
     src_strip_prefix = "src",
+    tags = ["no-cross"],
     visibility = [
         "//hs-cimple:__subpackages__",
         "//tools/haskell:__pkg__",
@@ -107,6 +111,7 @@ haskell_library(
     name = "comment-parser",
     srcs = [":CommentParser"],
     src_strip_prefix = "src",
+    tags = ["no-cross"],
     visibility = [
         "//hs-cimple:__subpackages__",
         "//tools/haskell:__pkg__",
@@ -133,6 +138,7 @@ haskell_library(
     name = "tree-parser",
     srcs = [":TreeParser"],
     src_strip_prefix = "src",
+    tags = ["no-cross"],
     visibility = [
         "//hs-cimple:__subpackages__",
         "//tools/haskell:__pkg__",
@@ -162,6 +168,7 @@ haskell_library(
         ],
     ),
     src_strip_prefix = "src",
+    tags = ["no-cross"],
     version = "0.0.19",
     visibility = ["//visibility:public"],
     deps = [

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -3,6 +3,7 @@ load("@rules_haskell//haskell:defs.bzl", "haskell_binary")
 haskell_binary(
     name = "cimplefmt",
     srcs = ["cimplefmt.hs"],
+    tags = ["no-cross"],
     visibility = ["//visibility:public"],
     deps = [
         "//hs-cimple",
@@ -15,6 +16,7 @@ haskell_binary(
 haskell_binary(
     name = "dump-ast",
     srcs = ["dump-ast.hs"],
+    tags = ["no-cross"],
     visibility = ["//visibility:public"],
     deps = [
         "//hs-cimple",
@@ -26,6 +28,7 @@ haskell_binary(
 haskell_binary(
     name = "count-tokens",
     srcs = ["count-tokens.hs"],
+    tags = ["no-cross"],
     visibility = ["//visibility:public"],
     deps = [
         "//hs-cimple",
@@ -39,6 +42,7 @@ haskell_binary(
 haskell_binary(
     name = "dump-tokens",
     srcs = ["dump-tokens.hs"],
+    tags = ["no-cross"],
     visibility = ["//visibility:public"],
     deps = [
         "//hs-cimple",
@@ -51,6 +55,7 @@ haskell_binary(
 haskell_binary(
     name = "include-graph",
     srcs = ["include-graph.hs"],
+    tags = ["no-cross"],
     visibility = ["//visibility:public"],
     deps = [
         "//hs-cimple",


### PR DESCRIPTION
This way we can do bazel build //... when cross-compiling.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/hs-cimple/93)
<!-- Reviewable:end -->
