### PR TITLE
feat: Add support for comment-escaping code.

### DIFF
--- a/src/Language/Cimple/Lexer.x
+++ b/src/Language/Cimple/Lexer.x
@@ -132,6 +132,8 @@ tokens :-
 <0>		[\ \n]+					;
 <0>		$white					{ mkE ErrorToken }
 <0>		"//!TOKSTYLE-"				{ mkL IgnStart `andBegin` ignoreSC }
+<0>		"/*!"					{ mkL CmtStartCode }
+<0>		"*/"					{ mkL CmtEnd }
 <0>		"/*"					{ mkL CmtStart `andBegin` cmtSC }
 <0>		"/**"					{ mkL CmtStartDoc `andBegin` cmtSC }
 <0>		"/** @{"				{ mkL CmtStartDocSection `andBegin` cmtSC }

--- a/src/Language/Cimple/Parser.y
+++ b/src/Language/Cimple/Parser.y
@@ -126,6 +126,7 @@ import           Language.Cimple.Tokens (LexemeClass (..))
     '#undef'			{ L _ PpUndef			_ }
     '\n'			{ L _ PpNewline			_ }
     '/*'			{ L _ CmtStart			_ }
+    '/*!'			{ L _ CmtStartCode		_ }
     '/**'			{ L _ CmtStartDoc		_ }
     '/** @{'			{ L _ CmtStartDocSection	_ }
     '/** @} */'			{ L _ CmtEndDocSection		_ }
@@ -439,6 +440,7 @@ DeclSpecArray :: { NonTerm }
 DeclSpecArray
 :	'[' ']'							{ Fix $ DeclSpecArray Nothing }
 |	'[' Expr ']'						{ Fix $ DeclSpecArray (Just $2) }
+|	'[' '/*!' Expr '*/' ']'					{ Fix $ DeclSpecArray (Just $3) }
 
 InitialiserExpr :: { NonTerm }
 InitialiserExpr

--- a/src/Language/Cimple/Tokens.hs
+++ b/src/Language/Cimple/Tokens.hs
@@ -109,6 +109,7 @@ data LexemeClass
     | CmtPrefix
     | CmtIndent
     | CmtStart
+    | CmtStartCode
     | CmtStartBlock
     | CmtStartDoc
     | CmtStartDocSection


### PR DESCRIPTION
Writing `/*! code */` will be interpreted by Cimple, but ignored by all other compilers/parsers. This allows us to put some expressions in places where otherwise C can't.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/hs-cimple/99)
<!-- Reviewable:end -->
