### PR TITLE
fix: Fix `showNode` to display ANSI colours.

### DIFF
--- a/src/Language/Cimple/Pretty.hs
+++ b/src/Language/Cimple/Pretty.hs
@@ -576,7 +576,7 @@ ppTranslationUnit :: [Node (Lexeme Text)] -> Doc AnsiStyle
 ppTranslationUnit decls = (ppToplevel . map ppNode $ decls) <> line
 
 showNode  :: Node (Lexeme Text) -> Text
-showNode = Text.pack . show . ppNode
+showNode = render . ppNode
 
 renderSmart :: Float -> Int -> Doc AnsiStyle -> SimpleDocStream AnsiStyle
 renderSmart ribbonFraction widthPerLine


### PR DESCRIPTION
Without this, tokstyle will not show colours in error messages.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/hs-cimple/113)
<!-- Reviewable:end -->
