### PR TITLE
feat: Add support for C++ style forward declares.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,19 @@
+---
+version: 2
+
+workflows:
+  version: 2
+  circleci:
+    jobs:
+      - bazel-opt
+
+jobs:
+  bazel-opt:
+    working_directory: /tmp/cirrus-ci-build
+    docker:
+      - image: toxchat/toktok-stack:latest-release
+
+    steps:
+      - checkout
+      - run: /src/workspace/tools/inject-repo hs-cimple
+      - run: cd /src/workspace && bazel test -k //hs-cimple/...

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,12 +1,12 @@
----
-bazel-opt_task:
-  container:
-    image: toxchat/toktok-stack:latest-release
-    cpu: 2
-    memory: 6G
-  configure_script:
-    - /src/workspace/tools/inject-repo hs-cimple
-  test_all_script:
-    - cd /src/workspace && bazel test -k
-        --config=ci
-        //hs-cimple/...
+# ---
+# bazel-opt_task:
+#   container:
+#     image: toxchat/toktok-stack:latest-release
+#     cpu: 2
+#     memory: 6G
+#   configure_script:
+#     - /src/workspace/tools/inject-repo hs-cimple
+#   test_all_script:
+#     - cd /src/workspace && bazel test -k
+#         --config=ci
+#         //hs-cimple/...

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -4,7 +4,10 @@ load("//third_party/haskell/happy:build_defs.bzl", "happy_parser")
 load("//third_party/haskell/hspec-discover:build_defs.bzl", "hspec_test")
 load("//tools/project:build_defs.bzl", "project")
 
-project(license = "gpl3-https")
+project(
+    custom_cirrus = True,
+    license = "gpl3-https",
+)
 
 alex_lexer(
     name = "Lexer",

--- a/src/Language/Cimple/Parser.y
+++ b/src/Language/Cimple/Parser.y
@@ -666,6 +666,7 @@ TypedefDecl :: { NonTerm }
 TypedefDecl
 :	typedef QualType ID_SUE_TYPE ';'			{ Fix $ Typedef $2 $3 }
 |	typedef FunctionPrototype(ID_FUNC_TYPE) ';'		{ Fix $ TypedefFunction $2 }
+|	struct ID_SUE_TYPE ';'					{ Fix $ Typedef (Fix (TyStruct $2)) $2 }
 
 QualType :: { NonTerm }
 QualType


### PR DESCRIPTION
In cimple, `struct X;` will now mean the same as `typedef struct X X;`, which is (roughly) the same behaviour as in C++. This is only to support having plain `struct X;` declarations where we put our comments vs. having the typedefs surrounded by ifdefs for C99 reasons (benign typedef redefinitions are a C11 feature).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/hs-cimple/120)
<!-- Reviewable:end -->
