### PR TITLE
fix: Support `GNU_PRINTF` attribute at start of function declaration.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -197,7 +197,7 @@ haskell_library(
         "haskell",
         "no-cross",
     ],
-    version = "0.0.23",
+    version = "0.0.24",
     visibility = ["//visibility:public"],
     deps = [
         ":ast",

--- a/cimple.cabal
+++ b/cimple.cabal
@@ -1,5 +1,5 @@
 name:          cimple
-version:       0.0.23
+version:       0.0.24
 synopsis:      Simple C-like programming language
 homepage:      https://toktok.github.io/
 license:       GPL-3

--- a/src/Language/Cimple/Parser.y
+++ b/src/Language/Cimple/Parser.y
@@ -706,6 +706,7 @@ FunctionDecl :: { NonTerm }
 FunctionDecl
 :	FunctionDeclarator					{ $1 Global }
 |	static FunctionDeclarator				{ $2 Static }
+|	Attrs FunctionDeclarator				{ $1 $ $2 Global }
 |	NonNull FunctionDeclarator				{ $1 $ $2 Global }
 |	NonNull static FunctionDeclarator			{ $1 $ $3 Static }
 |	NonNull Attrs FunctionDeclarator			{ $1 . $2 . $3 $ Global }

--- a/src/Language/Cimple/TreeParser.y
+++ b/src/Language/Cimple/TreeParser.y
@@ -121,6 +121,7 @@ import           Language.Cimple.Tokens        (LexemeClass (..))
     functionPrototype	{ Fix (FunctionPrototype{}) }
     ellipsis		{ Fix (Ellipsis) }
     nonNull		{ Fix (NonNull{}) }
+    attrPrintf		{ Fix (AttrPrintf{}) }
     -- Constants
     constDecl		{ Fix (ConstDecl{}) }
     constDefn		{ Fix (ConstDefn{}) }
@@ -195,6 +196,7 @@ CommentableDecl
 :	functionDecl						{ $1 }
 |	functionDefn						{ $1 }
 |	nonNull							{ $1 }
+|	attrPrintf						{ $1 }
 |	aggregateDecl						{ $1 }
 |	struct							{ $1 }
 |	typedef							{ $1 }


### PR DESCRIPTION
Previously it was always after a non-null attr.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/hs-cimple/123)
<!-- Reviewable:end -->
