### PR TITLE
feat: Ignore clang nullability qualifiers (for now).

### DIFF
--- a/src/Language/Cimple/Lexer.x
+++ b/src/Language/Cimple/Lexer.x
@@ -116,6 +116,10 @@ tokens :-
 -- Sodium constants.
 <0,ppSC>	"crypto_"[a-z0-9_]+[A-Z][A-Z0-9_]*	{ mkL IdConst }
 
+-- Clang nullability qualifiers (ignored for now).
+<0,ppSC>	"_Nonnull"				;
+<0,ppSC>	"_Nullable"				;
+
 -- Standard C (ish).
 <ppSC>		defined					{ mkL PpDefined }
 <ppSC>		\"[^\"]*\"				{ mkL LitString }


### PR DESCRIPTION
We'll implement them later, but this allows us to start using them in clang without support in cimple.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/hs-cimple/124)
<!-- Reviewable:end -->
