### PR TITLE
feat: add Bifunctor instances for AST nodes and comments.

### DIFF
--- a/doc/cimple.md
+++ b/doc/cimple.md
@@ -367,6 +367,39 @@ The Cimple lexer does not support all of C's numeric literal formats.
 A lone semicolon (`;`), which constitutes an empty statement in standard C, is
 not a valid statement in Cimple and will result in a parse error.
 
+### No Anonymous or Nested Aggregate Types
+
+To enforce naming conventions and simplify static analysis, all structs,
+unions, and enums must be defined at the top level (global scope) and must be
+named. Anonymous aggregate types and aggregate types defined within another
+struct or union are not supported.
+
+**Invalid:**
+
+```c
+struct My_Struct {
+    int x;
+    union { // Anonymous nested union
+        int a;
+        float b;
+    } data;
+};
+```
+
+**Valid:**
+
+```c
+union My_Union {
+    int a;
+    float b;
+};
+
+struct My_Struct {
+    int x;
+    union My_Union data;
+};
+```
+
 ## 4. Supported C Features
 
 ### Variadic Functions

--- a/src/Language/Cimple.hs
+++ b/src/Language/Cimple.hs
@@ -14,6 +14,7 @@ import           Data.Text                   (Text)
 import           Language.Cimple.Annot       as X
 import           Language.Cimple.Ast         as X
 import           Language.Cimple.DescribeAst as X
+import           Language.Cimple.Flatten     as X
 import           Language.Cimple.Lexer       as X
 import           Language.Cimple.MapAst      as X
 import           Language.Cimple.Parser      as X

--- a/src/Language/Cimple/Flatten.hs
+++ b/src/Language/Cimple/Flatten.hs
@@ -4,7 +4,7 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE Strict                #-}
 {-# LANGUAGE TypeOperators         #-}
-module Language.Cimple.Flatten (lexemes) where
+module Language.Cimple.Flatten (Concats (..), lexemes) where
 
 import           Data.Fix            (Fix (..))
 import           Data.Maybe          (maybeToList)
@@ -45,6 +45,9 @@ instance GenConcatsFlatten Scope        a where gconcatsFlatten = const []
 instance GenConcatsFlatten CommentStyle a where gconcatsFlatten = const []
 instance GenConcatsFlatten LiteralType  a where gconcatsFlatten = const []
 instance GenConcatsFlatten Nullability  a where gconcatsFlatten = const []
+
+instance (GenConcatsFlatten b a, GenConcatsFlatten c a) => GenConcatsFlatten (b, c) a where
+    gconcatsFlatten (x, y) = gconcatsFlatten x ++ gconcatsFlatten y
 
 instance GenConcatsFlatten b a => GenConcatsFlatten (Maybe b) a where
     gconcatsFlatten = gconcatsFlatten . maybeToList

--- a/src/Language/Cimple/Pretty.hs
+++ b/src/Language/Cimple/Pretty.hs
@@ -5,6 +5,8 @@ module Language.Cimple.Pretty
     , render
     , renderSmart
     , ppTranslationUnit
+    , ppNode
+    , ppNodeF
     , showNode
     , showNodePlain
     ) where
@@ -199,10 +201,10 @@ ppMacroBody =
     . plain
 
 ppNode :: Pretty a => Node (Lexeme a) -> Doc AnsiStyle
-ppNode = foldFix go
-  where
-  go :: Pretty a => NodeF (Lexeme a) (Doc AnsiStyle) -> Doc AnsiStyle
-  go = \case
+ppNode = foldFix ppNodeF
+
+ppNodeF :: Pretty a => NodeF (Lexeme a) (Doc AnsiStyle) -> Doc AnsiStyle
+ppNodeF = \case
     StaticAssert cond msg ->
         kwStaticAssert <> parens (cond <> comma <+> dullred (ppLexeme msg)) <> semi
 

--- a/test/Language/Cimple/AstSpec.hs
+++ b/test/Language/Cimple/AstSpec.hs
@@ -4,15 +4,19 @@
 {-# LANGUAGE ViewPatterns      #-}
 module Language.Cimple.AstSpec where
 
+import           Data.Bifunctor       (Bifunctor (..))
 import           Data.Fix             (Fix (..))
 import           Data.Functor.Compose (Compose (..))
 import           Test.Hspec           (Spec, describe, it, shouldBe,
                                        shouldSatisfy)
 
-import           Language.Cimple      (AlexPosn (..), AnnotF (..), Lexeme (..),
-                                       LexemeClass (..), LiteralType (..),
-                                       NodeF (..), Scope (..), addAnnot,
-                                       removeAnnot)
+import           Language.Cimple      (AlexPosn (..), AnnotF (..),
+                                       AssignOp (..), BinaryOp (..),
+                                       CommentF (..), CommentStyle (..),
+                                       Lexeme (..), LexemeClass (..),
+                                       LiteralType (..), NodeF (..),
+                                       Nullability (..), Scope (..),
+                                       UnaryOp (..), addAnnot, removeAnnot)
 import           Language.Cimple.IO   (parseText)
 
 
@@ -38,3 +42,149 @@ spec = do
                     (L (AlexPn 10 1 11) IdVar "a")
                     (Fix (LiteralExpr Int (L (AlexPn 14 1 15) LitInteger "3"))))) -> True
                 _ -> False
+
+    describe "Bifunctor NodeF" $ do
+        it "bimap maps lexemes and children" $ do
+            let fl l = "l-" ++ l
+            let fa a = "a-" ++ a
+            let test n e = bimap fl fa n `shouldBe` e
+
+            -- Preprocessor
+            test (PreprocInclude "inc") (PreprocInclude "l-inc")
+            test (PreprocDefine "def") (PreprocDefine "l-def")
+            test (PreprocDefineConst "def" "const") (PreprocDefineConst "l-def" "a-const")
+            test (PreprocDefineMacro "def" ["p1", "p2"] "body") (PreprocDefineMacro "l-def" ["a-p1", "a-p2"] "a-body")
+            test (PreprocIf "cond" ["as"] "else") (PreprocIf "a-cond" ["a-as"] "a-else")
+            test (PreprocIfdef "def" ["as"] "else") (PreprocIfdef "l-def" ["a-as"] "a-else")
+            test (PreprocIfndef "def" ["as"] "else") (PreprocIfndef "l-def" ["a-as"] "a-else")
+            test (PreprocElse ["as"]) (PreprocElse ["a-as"])
+            test (PreprocElif "cond" ["as"] "else") (PreprocElif "a-cond" ["a-as"] "a-else")
+            test (PreprocUndef "def") (PreprocUndef "l-def")
+            test (PreprocDefined "def") (PreprocDefined "l-def")
+            test (PreprocScopedDefine "a" ["as"] "a'") (PreprocScopedDefine "a-a" ["a-as"] "a-a'")
+            test (MacroBodyStmt "a") (MacroBodyStmt "a-a")
+            test (MacroBodyFunCall "a") (MacroBodyFunCall "a-a")
+            test (MacroParam "l") (MacroParam "l-l")
+            test (StaticAssert "a" "l") (StaticAssert "a-a" "l-l")
+
+            -- Comments
+            test (LicenseDecl "l" ["as"]) (LicenseDecl "l-l" ["a-as"])
+            test (CopyrightDecl "l" (Just "ml") ["ls"]) (CopyrightDecl "l-l" (Just "l-ml") ["l-ls"])
+            test (Comment Regular "l" ["ls"] "l'") (Comment Regular "l-l" ["l-ls"] "l-l'")
+            test (CommentSection "a" ["as"] "a'") (CommentSection "a-a" ["a-as"] "a-a'")
+            test (CommentSectionEnd "l") (CommentSectionEnd "l-l")
+            test (Commented "a" "a'") (Commented "a-a" "a-a'")
+            test (CommentInfo (Fix (DocWord "l"))) (CommentInfo (Fix (DocWord "l-l")))
+
+            -- Namespace-like blocks
+            test (ExternC ["as"]) (ExternC ["a-as"])
+            test (Group ["as"]) (Group ["a-as"])
+
+            -- Statements
+            test (CompoundStmt ["as"]) (CompoundStmt ["a-as"])
+            test Break Break
+            test (Goto "l") (Goto "l-l")
+            test Continue Continue
+            test (Return (Just "ma")) (Return (Just "a-ma"))
+            test (SwitchStmt "a" ["as"]) (SwitchStmt "a-a" ["a-as"])
+            test (IfStmt "a" "a'" (Just "ma''")) (IfStmt "a-a" "a-a'" (Just "a-ma''"))
+            test (ForStmt "a" "a'" "a''" "a'''") (ForStmt "a-a" "a-a'" "a-a''" "a-a'''")
+            test (WhileStmt "a" "as") (WhileStmt "a-a" "a-as")
+            test (DoWhileStmt "a" "a'") (DoWhileStmt "a-a" "a-a'")
+            test (Case "a" "a'") (Case "a-a" "a-a'")
+            test (Default "a") (Default "a-a")
+            test (Label "l" "a") (Label "l-l" "a-a")
+            test (ExprStmt "a") (ExprStmt "a-a")
+
+            -- Variable declarations
+            test (VLA "a" "l" "a'") (VLA "a-a" "l-l" "a-a'")
+            test (VarDeclStmt "a" (Just "ma")) (VarDeclStmt "a-a" (Just "a-ma"))
+            test (VarDecl "a" "l" ["as"]) (VarDecl "a-a" "l-l" ["a-as"])
+            test (DeclSpecArray (Just "ma")) (DeclSpecArray (Just "a-ma"))
+            test (ArrayDim NullabilityUnspecified "a") (ArrayDim NullabilityUnspecified "a-a")
+
+            -- Expressions
+            test (InitialiserList ["as"]) (InitialiserList ["a-as"])
+            test (UnaryExpr UopNot "a") (UnaryExpr UopNot "a-a")
+            test (BinaryExpr "a" BopEq "a'") (BinaryExpr "a-a" BopEq "a-a'")
+            test (TernaryExpr "a" "a'" "a''") (TernaryExpr "a-a" "a-a'" "a-a''")
+            test (AssignExpr "a" AopEq "a'") (AssignExpr "a-a" AopEq "a-a'")
+            test (ParenExpr "a") (ParenExpr "a-a")
+            test (CastExpr "a" "a'") (CastExpr "a-a" "a-a'")
+            test (CompoundExpr "a" "a'") (CompoundExpr "a-a" "a-a'")
+            test (CompoundLiteral "a" "a'") (CompoundLiteral "a-a" "a-a'")
+            test (SizeofExpr "a") (SizeofExpr "a-a")
+            test (SizeofType "a") (SizeofType "a-a")
+            test (LiteralExpr Int "l") (LiteralExpr Int "l-l")
+            test (VarExpr "l") (VarExpr "l-l")
+            test (MemberAccess "a" "l") (MemberAccess "a-a" "l-l")
+            test (PointerAccess "a" "l") (PointerAccess "a-a" "l-l")
+            test (ArrayAccess "a" "a'") (ArrayAccess "a-a" "a-a'")
+            test (FunctionCall "a" ["as"]) (FunctionCall "a-a" ["a-as"])
+            test (CommentExpr "a" "a'") (CommentExpr "a-a" "a-a'")
+
+            -- Type definitions
+            test (EnumConsts (Just "ml") ["as"]) (EnumConsts (Just "l-ml") ["a-as"])
+            test (EnumDecl "l" ["as"] "l'") (EnumDecl "l-l" ["a-as"] "l-l'")
+            test (Enumerator "l" (Just "ma")) (Enumerator "l-l" (Just "a-ma"))
+            test (AggregateDecl "a") (AggregateDecl "a-a")
+            test (Typedef "a" "l") (Typedef "a-a" "l-l")
+            test (TypedefFunction "a") (TypedefFunction "a-a")
+            test (Struct "l" ["as"]) (Struct "l-l" ["a-as"])
+            test (Union "l" ["as"]) (Union "l-l" ["a-as"])
+            test (MemberDecl "a" (Just "ml")) (MemberDecl "a-a" (Just "l-ml"))
+            test (TyBitwise "a") (TyBitwise "a-a")
+            test (TyForce "a") (TyForce "a-a")
+            test (TyConst "a") (TyConst "a-a")
+            test (TyOwner "a") (TyOwner "a-a")
+            test (TyNonnull "a") (TyNonnull "a-a")
+            test (TyNullable "a") (TyNullable "a-a")
+            test (TyPointer "a") (TyPointer "a-a")
+            test (TyStruct "l") (TyStruct "l-l")
+            test (TyUnion "l") (TyUnion "l-l")
+            test (TyFunc "l") (TyFunc "l-l")
+            test (TyStd "l") (TyStd "l-l")
+            test (TyUserDefined "l") (TyUserDefined "l-l")
+
+            -- Functions
+            test (AttrPrintf "l" "l'" "a") (AttrPrintf "l-l" "l-l'" "a-a")
+            test (FunctionDecl Global "a") (FunctionDecl Global "a-a")
+            test (FunctionDefn Global "a" "a'") (FunctionDefn Global "a-a" "a-a'")
+            test (FunctionPrototype "a" "l" ["as"]) (FunctionPrototype "a-a" "l-l" ["a-as"])
+            test (CallbackDecl "l" "l'") (CallbackDecl "l-l" "l-l'")
+            test Ellipsis Ellipsis
+            test (NonNull ["ls"] ["ls'"] "a") (NonNull ["l-ls"] ["l-ls'"] "a-a")
+            test (NonNullParam "a") (NonNullParam "a-a")
+            test (NullableParam "a") (NullableParam "a-a")
+
+            -- Constants
+            test (ConstDecl "a" "l") (ConstDecl "a-a" "l-l")
+            test (ConstDefn Global "a" "l" "a'") (ConstDefn Global "a-a" "l-l" "a-a'")
+
+    describe "Bifunctor CommentF" $ do
+        it "bimap maps lexemes and children" $ do
+            let fl l = "l-" ++ l
+            let fa a = "a-" ++ a
+            let test n e = bimap fl fa n `shouldBe` e
+
+            test (DocComment ["as"]) (DocComment ["a-as"])
+            test DocAttention DocAttention
+            test DocBrief DocBrief
+            test DocDeprecated DocDeprecated
+            test (DocExtends "l") (DocExtends "l-l")
+            test DocFile DocFile
+            test (DocImplements "l") (DocImplements "l-l")
+            test DocNote DocNote
+            test (DocParam (Just "ml") "l") (DocParam (Just "l-ml") "l-l")
+            test DocReturn DocReturn
+            test DocRetval DocRetval
+            test (DocSection "l") (DocSection "l-l")
+            test (DocSecurityRank "l" (Just "ml") "l'") (DocSecurityRank "l-l" (Just "l-ml") "l-l'")
+            test (DocSee "l") (DocSee "l-l")
+            test (DocSubsection "l") (DocSubsection "l-l")
+            test DocPrivate DocPrivate
+            test (DocLine ["as"]) (DocLine ["a-as"])
+            test (DocCode "l" ["as"] "l'") (DocCode "l-l" ["a-as"] "l-l'")
+            test (DocWord "l") (DocWord "l-l")
+            test (DocRef "l") (DocRef "l-l")
+            test (DocP "l") (DocP "l-l")


### PR DESCRIPTION
- Implement Bifunctor for NodeF and CommentF, enabling independent mapping over lexemes and child nodes/comments.
- Export ppNodeF from Language.Cimple.Pretty for granular node pretty-printing.
- Export Flatten.Concats for externalising more AST work.
- Document the restriction against anonymous or nested aggregate types in doc/cimple.md.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/hs-cimple/134)
<!-- Reviewable:end -->
