### PR TITLE
fix: Add support for ASCII versions of winapi functions.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -55,6 +55,7 @@ haskell_library(
         "//tools/haskell:__pkg__",
     ],
     deps = [
+        "//third_party/haskell:QuickCheck",
         "//third_party/haskell:aeson",
         "//third_party/haskell:base",
         "//third_party/haskell:data-fix",
@@ -202,7 +203,7 @@ haskell_library(
         "haskell",
         "no-cross",
     ],
-    version = "0.0.28",
+    version = "0.0.29",
     visibility = ["//visibility:public"],
     deps = [
         ":ast",

--- a/cimple.cabal
+++ b/cimple.cabal
@@ -1,5 +1,5 @@
 name:          cimple
-version:       0.0.28
+version:       0.0.29
 synopsis:      Simple C-like programming language
 homepage:      https://toktok.github.io/
 license:       GPL-3

--- a/src/Language/Cimple/Ast.hs
+++ b/src/Language/Cimple/Ast.hs
@@ -26,6 +26,8 @@ import           Data.Functor.Classes.Generic (FunctorClassesDefault (..))
 import           Data.Hashable                (Hashable (..))
 import           Data.Hashable.Lifted         (Hashable1)
 import           GHC.Generics                 (Generic, Generic1)
+import           Test.QuickCheck              (Arbitrary (..),
+                                               arbitraryBoundedEnum)
 
 getNodeId :: Hashable a => Node a -> Int
 getNodeId = hash
@@ -404,3 +406,24 @@ instance Hashable LiteralType where
 instance Hashable Scope where
 instance Hashable CommentStyle where
 instance Hashable Nullability where
+
+instance Arbitrary AssignOp where
+    arbitrary = arbitraryBoundedEnum
+
+instance Arbitrary BinaryOp where
+    arbitrary = arbitraryBoundedEnum
+
+instance Arbitrary UnaryOp where
+    arbitrary = arbitraryBoundedEnum
+
+instance Arbitrary LiteralType where
+    arbitrary = arbitraryBoundedEnum
+
+instance Arbitrary Scope where
+    arbitrary = arbitraryBoundedEnum
+
+instance Arbitrary CommentStyle where
+    arbitrary = arbitraryBoundedEnum
+
+instance Arbitrary Nullability where
+    arbitrary = arbitraryBoundedEnum

--- a/src/Language/Cimple/Lexer.x
+++ b/src/Language/Cimple/Lexer.x
@@ -58,11 +58,12 @@ tokens :-
 <0>		"QueryPerformanceCounter"		{ mkL IdVar }
 <0>		"QueryPerformanceFrequency"		{ mkL IdVar }
 <0>		"SecureZeroMemory"			{ mkL IdVar }
-<0>		"WSAAddressToString"			{ mkL IdVar }
+<0>		"WSAAddressToString"("A"?)		{ mkL IdVar }
 <0>		"WSACleanup"				{ mkL IdVar }
 <0>		"WSAGetLastError"			{ mkL IdVar }
+<0>		"WSASetLastError"			{ mkL IdVar }
 <0>		"WSAStartup"				{ mkL IdVar }
-<0>		"WSAStringToAddress"			{ mkL IdVar }
+<0>		"WSAStringToAddress"("A"?)		{ mkL IdVar }
 
 -- Winapi struct members.
 <0>		"GatewayList"				{ mkL IdVar }
@@ -79,6 +80,7 @@ tokens :-
 <0>		"INT"					{ mkL IdStdType }
 <0>		"LPSOCKADDR"				{ mkL IdStdType }
 <0>		"IP_ADAPTER_INFO"			{ mkL IdStdType }
+<0>		"LPSTR"					{ mkL IdStdType }
 <0>		"LPTSTR"				{ mkL IdStdType }
 <0>		"u_long"				{ mkL IdStdType }
 <0>		"LARGE_INTEGER"				{ mkL IdStdType }


### PR DESCRIPTION
We're now supporting the A versions in addition to the TSTR versions.

Also added quickcheck generators for some commonly tested types.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/hs-cimple/139)
<!-- Reviewable:end -->
