### PR TITLE
fix: Better support for nullability annotations on non-pointers.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -203,7 +203,7 @@ haskell_library(
         "haskell",
         "no-cross",
     ],
-    version = "0.0.30",
+    version = "0.0.31",
     visibility = ["//visibility:public"],
     deps = [
         ":ast",

--- a/cimple.cabal
+++ b/cimple.cabal
@@ -1,5 +1,5 @@
 name:          cimple
-version:       0.0.30
+version:       0.0.31
 synopsis:      Simple C-like programming language
 homepage:      https://toktok.github.io/
 license:       GPL-3
@@ -31,6 +31,7 @@ library
     Language.Cimple.Pretty
     Language.Cimple.Program
     Language.Cimple.TraverseAst
+    Language.Cimple.TranslationUnit
 
   other-modules:
     Language.Cimple.Annot
@@ -49,7 +50,6 @@ library
     Language.Cimple.PrettyCommon
     Language.Cimple.SemCheck.Includes
     Language.Cimple.Tokens
-    Language.Cimple.TranslationUnit
     Language.Cimple.TreeParser
 
   build-depends:

--- a/src/Language/Cimple/Parser.y
+++ b/src/Language/Cimple/Parser.y
@@ -692,18 +692,12 @@ TypedefDecl
 QualType(leafType)
 :	bitwise ID_STD_TYPE					{ Fix (TyBitwise (Fix (TyStd $2))) }
 |	force QualType(leafType)				{ Fix (TyForce $2) }
-|	leafType ConstQual					{                              ($2      $1)    }
-|	leafType ConstQual '*'					{                (tyPointer ($2      $1))   }
-|	leafType ConstQual '*' QualList				{                $4 (tyPointer ($2      $1))   }
-|	leafType ConstQual '*' QualMaybe '*' QualMaybe		{ $6 (tyPointer ($4 (tyPointer ($2      $1)))) }
-|	const leafType						{                              (tyConst $2)    }
-|	const leafType '*' QualMaybe				{                $4 (tyPointer (tyConst $2))   }
-|	const leafType '*' QualMaybe '*' QualMaybe		{ $6 (tyPointer ($4 (tyPointer (tyConst $2)))) }
+|	PtrType(leafType)					{ $1 }
 
-ConstQual :: { NonTerm -> NonTerm }
-ConstQual
-:								{ id }
-|	const							{ tyConst }
+PtrType(leafType)
+:	leafType QualMaybe					{ $2 $1 }
+|	const leafType QualMaybe				{ $3 (tyConst $2) }
+|	PtrType(leafType) '*' QualMaybe				{ $3 (tyPointer $1) }
 
 QualList :: { NonTerm -> NonTerm }
 QualList

--- a/test/Language/Cimple/ParserSpec.hs
+++ b/test/Language/Cimple/ParserSpec.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE LambdaCase        #-}
 {-# LANGUAGE OverloadedStrings #-}
 module Language.Cimple.ParserSpec where
 
@@ -139,6 +140,12 @@ spec = do
         it "should parse a comment" $ do
             let ast = parseText "/* hello */"
             ast `shouldSatisfy` isRight1
+
+        it "should parse postfix nullability on a pointer" $ do
+            let ast = parseText "void foo(int _Nonnull *p);"
+            case ast of
+                Right [Fix (FunctionDecl _ (Fix (FunctionPrototype _ _ [Fix (VarDecl (Fix (TyPointer (Fix (TyNonnull (Fix (TyStd _)))))) (L _ _ "p") [])])))] -> return ()
+                _ -> expectationFailure $ "Unexpected AST: " ++ show ast
 
         it "supports single declarators" $ do
             let ast = parseText "int main() { int a; }"


### PR DESCRIPTION
Non-pointer types may be typedefs that contain pointer types or arrays.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/hs-cimple/144)
<!-- Reviewable:end -->
