### PR TITLE
feat: Add support for multi-file diagnostic spans.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -203,7 +203,7 @@ haskell_library(
         "haskell",
         "no-cross",
     ],
-    version = "0.0.31",
+    version = "0.0.32",
     visibility = ["//visibility:public"],
     deps = [
         ":ast",

--- a/cimple.cabal
+++ b/cimple.cabal
@@ -1,5 +1,5 @@
 name:          cimple
-version:       0.0.31
+version:       0.0.32
 synopsis:      Simple C-like programming language
 homepage:      https://toktok.github.io/
 license:       GPL-3

--- a/test/Language/Cimple/DiagnosticsSpec.hs
+++ b/test/Language/Cimple/DiagnosticsSpec.hs
@@ -313,6 +313,39 @@ spec = do
                 , "    |     ^"
                 ]
 
+        it "renders multiple spans in different files" $ do
+            let cache = Map.fromList
+                    [ ("file1.c", ["line 1 in file 1"])
+                    , ("file2.h", ["line 1 in file 2"])
+                    ]
+            let diag = Diagnostic
+                    { diagPos = CimplePos "file1.c" 1 1
+                    , diagLen = 4
+                    , diagLevel = ErrorLevel
+                    , diagMsg = "error across files"
+                    , diagFlag = Nothing
+                    , diagSpans =
+                        [ DiagnosticSpan (CimplePos "file1.c" 1 1) 4 ["primary"]
+                        , DiagnosticSpan (CimplePos "file2.h" 1 1) 4 ["secondary"]
+                        ]
+                    , diagFooter = []
+                    }
+            shouldRenderTo cache [diag]
+                [ "error: error across files"
+                , "   --> file1.c:1:1"
+                , "    |"
+                , "   1| line 1 in file 1"
+                , "    | ^^^^"
+                , "    | |"
+                , "    | primary"
+                , "   ::: file2.h:1:1"
+                , "    |"
+                , "   1| line 1 in file 2"
+                , "    | ^^^^"
+                , "    | |"
+                , "    | secondary"
+                ]
+
     describe "diagToText" $ do
         it "converts diagnostic to simple text format" $ do
             let diag = Diagnostic


### PR DESCRIPTION
This makes it possible to have diagnostics about .c files referencing .h files (e.g. declarations and definitions).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/hs-cimple/145)
<!-- Reviewable:end -->
