### PR TITLE
fix: Allow functions returning callbacks to be nullable.

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -203,7 +203,7 @@ haskell_library(
         "haskell",
         "no-cross",
     ],
-    version = "0.0.32",
+    version = "0.0.33",
     visibility = ["//visibility:public"],
     deps = [
         ":ast",

--- a/cimple.cabal
+++ b/cimple.cabal
@@ -1,5 +1,5 @@
 name:          cimple
-version:       0.0.32
+version:       0.0.33
 synopsis:      Simple C-like programming language
 homepage:      https://toktok.github.io/
 license:       GPL-3

--- a/src/Language/Cimple/Parser.y
+++ b/src/Language/Cimple/Parser.y
@@ -757,7 +757,7 @@ CallbackDecl
 
 FunctionPrototype(id)
 :	QualType(GlobalLeafType) id FunctionParamList		{ Fix $ FunctionPrototype $1 $2 $3 }
-|	ID_FUNC_TYPE '*' id FunctionParamList			{ Fix $ FunctionPrototype (Fix $ TyPointer $ Fix $ TyFunc $1) $3 $4 }
+|	ID_FUNC_TYPE '*' QualMaybe id FunctionParamList		{ Fix $ FunctionPrototype ($3 (Fix $ TyPointer $ Fix $ TyFunc $1)) $4 $5 }
 
 FunctionParamList :: { [NonTerm] }
 FunctionParamList

--- a/test/Language/Cimple/ParserSpec.hs
+++ b/test/Language/Cimple/ParserSpec.hs
@@ -147,6 +147,10 @@ spec = do
                 Right [Fix (FunctionDecl _ (Fix (FunctionPrototype _ _ [Fix (VarDecl (Fix (TyPointer (Fix (TyNonnull (Fix (TyStd _)))))) (L _ _ "p") [])])))] -> return ()
                 _ -> expectationFailure $ "Unexpected AST: " ++ show ast
 
+        it "should parse a function returning a nullable callback" $ do
+            let ast = parseText "tox_log_cb *_Nullable tox_options_get_log_callback(void);"
+            ast `shouldSatisfy` isRight1
+
         it "supports single declarators" $ do
             let ast = parseText "int main() { int a; }"
             ast `shouldBe` Right


### PR DESCRIPTION
E.g. `some_cb *_Nullable get_handler();`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/hs-cimple/146)
<!-- Reviewable:end -->
